### PR TITLE
Update `list`, `find` and `sort` commands

### DIFF
--- a/src/main/java/seedu/application/logic/Messages.java
+++ b/src/main/java/seedu/application/logic/Messages.java
@@ -14,10 +14,11 @@ import seedu.application.model.job.Job;
 public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown Command.\n" + HelpCommand.MESSAGE_USAGE;
-    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s\n";
+    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n\n%1$s\n";
     public static final String MESSAGE_INVALID_JOB_DISPLAYED_INDEX = "The job index provided is invalid!";
-    public static final String MESSAGE_INVALID_SPECIFIER = "The field specifier provided is invalid!";
-    public static final String MESSAGE_JOBS_LISTED_OVERVIEW = "%1$d jobs listed!";
+    public static final String MESSAGE_INVALID_PREFIX = "The prefix provided is invalid!";
+    public static final String MESSAGE_INVALID_SPECIFIER = "The field specifier provided is invalid";
+    public static final String MESSAGE_JOBS_LISTED_OVERVIEW = "%1$d jobs found!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
         "Multiple values specified for the following single-valued field(s): ";
 

--- a/src/main/java/seedu/application/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/application/logic/commands/FindCommand.java
@@ -1,29 +1,44 @@
 package seedu.application.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_COMPANY;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_DEADLINE;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_INDUSTRY;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_JOB_TYPE;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_STATUS;
 
 import seedu.application.commons.util.ToStringBuilder;
 import seedu.application.logic.Messages;
 import seedu.application.model.Model;
-import seedu.application.model.job.FieldContainsKeywordsPredicate;
+import seedu.application.model.job.CombinedPredicate;
 
 /**
  * Finds and lists all jobs in application book whose field contains any of the argument keywords.
  * Field is specified by the user.
- * Keyword matching is case insensitive.
+ * Keyword matching is case-insensitive.
  */
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all jobs whose field contains any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: FIELD_SPECIFIER KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " -r software database network";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all jobs that contain all of "
+            + "the specified keywords (case-insensitive) in the corresponding fields and displays them as a list with "
+            + "index numbers.\n\n"
+            + "Parameters: "
+            + "[" + PREFIX_COMPANY + "KEYWORDS] "
+            + "[" + PREFIX_ROLE + "KEYWORDS] "
+            + "[" + PREFIX_STATUS + "KEYWORDS] "
+            + "[" + PREFIX_INDUSTRY + "KEYWORDS] "
+            + "[" + PREFIX_DEADLINE + "KEYWORDS] "
+            + "[" + PREFIX_JOB_TYPE + "KEYWORDS]\n\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_COMPANY + "Google";
 
-    private final FieldContainsKeywordsPredicate predicate;
+    public static final String MESSAGE_EMPTY_KEYWORDS = "Missing keywords";
 
-    public FindCommand(FieldContainsKeywordsPredicate predicate) {
+    private final CombinedPredicate predicate;
+
+    public FindCommand(CombinedPredicate predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/application/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/application/logic/commands/ListCommand.java
@@ -1,58 +1,24 @@
 package seedu.application.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.application.model.Model.PREDICATE_SHOW_ALL_JOBS;
 
 import seedu.application.model.Model;
-import seedu.application.model.job.FieldComparator;
 
 /**
- * Lists all jobs in the application book to the user.
- * List order is based on the specifier provided.
- * If no specifier is provided, jobs are listed in the order they were added.
+ * Lists all persons in the address book to the user.
  */
 public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
-    public static final String MESSAGE_SUCCESS = "Listed jobs";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts the current list of jobs based on "
-            + "the specified field and displays them as a list with index numbers.\n"
-            + "Parameters: FIELD_SPECIFIER\n\n"
-            + "Example: " + COMMAND_WORD + " -c";
+    public static final String MESSAGE_SUCCESS = "Listed all %d jobs!";
 
-    public static final String MESSAGE_INVALID_SPECIFIER = "Specifiers should only be one of the following:\n"
-            + "-c (Company), -r (Role), -d (Deadline), -s (Status)";
-
-    private final FieldComparator comparator;
-
-    public ListCommand(FieldComparator comparator) {
-        this.comparator = comparator;
-    }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredJobList(Model.PREDICATE_SHOW_ALL_JOBS);
-        if (comparator.hasSpecifier()) {
-            model.sortJobs(comparator);
-        } else {
-            model.unsortJobs();
-        }
-        return new CommandResult(MESSAGE_SUCCESS);
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (other == this) {
-            return true;
-        }
-
-        // instanceof handles nulls
-        if (!(other instanceof ListCommand)) {
-            return false;
-        }
-
-        ListCommand otherListCommand = (ListCommand) other;
-        return comparator.equals(otherListCommand.comparator);
+        model.updateFilteredJobList(PREDICATE_SHOW_ALL_JOBS);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, model.getFilteredJobList().size()));
     }
 }

--- a/src/main/java/seedu/application/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/application/logic/commands/SortCommand.java
@@ -1,6 +1,12 @@
 package seedu.application.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_COMPANY;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_DEADLINE;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_INDUSTRY;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_JOB_TYPE;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_STATUS;
 
 import seedu.application.model.Model;
 import seedu.application.model.job.FieldComparator;
@@ -17,10 +23,15 @@ public class SortCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts the list of jobs based on "
             + "the specified field and displays them as a list with index numbers.\n"
             + "Parameters: FIELD\n\n"
-            + "Example: " + COMMAND_WORD + " -c";
+            + "Example: " + COMMAND_WORD + PREFIX_ROLE;
 
-    public static final String MESSAGE_INVALID_SPECIFIER = "Specifiers should only be one of the following:\n"
-            + "-c (Company), -r (Role), -d (Deadline), -s (Status)";
+    public static final String MESSAGE_INVALID_SPECIFIER = "Specifiers should only be one of the following: "
+            + PREFIX_COMPANY + " (Company), "
+            + PREFIX_ROLE + " (Role), "
+            + PREFIX_STATUS + " (Status), "
+            + PREFIX_INDUSTRY + " (Industry), "
+            + PREFIX_DEADLINE + " (Deadline), "
+            + PREFIX_JOB_TYPE + " (Job Type)";
 
     private final FieldComparator comparator;
 

--- a/src/main/java/seedu/application/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/application/logic/commands/SortCommand.java
@@ -1,0 +1,56 @@
+package seedu.application.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.application.model.Model;
+import seedu.application.model.job.FieldComparator;
+
+/**
+ * Lists all jobs in the application book to the user.
+ * Sort order is based on the specifier provided.
+ */
+public class SortCommand extends Command {
+
+    public static final String COMMAND_WORD = "sort";
+    public static final String MESSAGE_SUCCESS = "Sorted jobs";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts the list of jobs based on "
+            + "the specified field and displays them as a list with index numbers.\n"
+            + "Parameters: FIELD\n\n"
+            + "Example: " + COMMAND_WORD + " -c";
+
+    public static final String MESSAGE_INVALID_SPECIFIER = "Specifiers should only be one of the following:\n"
+            + "-c (Company), -r (Role), -d (Deadline), -s (Status)";
+
+    private final FieldComparator comparator;
+
+    /**
+     * @param comparator The comparator used to sort jobs in the list.
+     */
+    public SortCommand(FieldComparator comparator) {
+        requireNonNull(comparator);
+        this.comparator = comparator;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.sortJobs(comparator);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof SortCommand)) {
+            return false;
+        }
+
+        SortCommand otherListCommand = (SortCommand) other;
+        return comparator.equals(otherListCommand.comparator);
+    }
+}

--- a/src/main/java/seedu/application/logic/parser/ApplicationBookParser.java
+++ b/src/main/java/seedu/application/logic/parser/ApplicationBookParser.java
@@ -17,6 +17,7 @@ import seedu.application.logic.commands.ExitCommand;
 import seedu.application.logic.commands.FindCommand;
 import seedu.application.logic.commands.HelpCommand;
 import seedu.application.logic.commands.ListCommand;
+import seedu.application.logic.commands.SortCommand;
 import seedu.application.logic.parser.exceptions.ParseException;
 
 /**
@@ -69,7 +70,10 @@ public class ApplicationBookParser {
             return new FindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommandParser().parse(arguments);
+            return new ListCommand();
+
+        case SortCommand.COMMAND_WORD:
+            return new SortCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/application/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/application/logic/parser/ArgumentMultimap.java
@@ -23,6 +23,20 @@ public class ArgumentMultimap {
     private final Map<Prefix, List<String>> argMultimap = new HashMap<>();
 
     /**
+     * Returns the {@code argMultiMap} object.
+     */
+    public Map<Prefix, List<String>> getArgMultimap() {
+        return argMultimap;
+    }
+
+    /**
+     * Returns the size of the {@code argMultiMap} object.
+     */
+    public int size() {
+        return argMultimap.size();
+    }
+
+    /**
      * Associates the specified argument value with {@code prefix} key in this map.
      * If the map previously contained a mapping for the key, the new value is appended to the list of existing values.
      *

--- a/src/main/java/seedu/application/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/application/logic/parser/FindCommandParser.java
@@ -1,13 +1,21 @@
 package seedu.application.logic.parser;
 
 import static seedu.application.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.application.logic.Messages.MESSAGE_INVALID_SPECIFIER;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_COMPANY;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_DEADLINE;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_INDUSTRY;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_JOB_TYPE;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_STATUS;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
+import seedu.application.logic.Messages;
 import seedu.application.logic.commands.FindCommand;
 import seedu.application.logic.parser.exceptions.ParseException;
+import seedu.application.model.job.CombinedPredicate;
 import seedu.application.model.job.FieldContainsKeywordsPredicate;
 
 /**
@@ -21,34 +29,49 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform to the expected format.
      */
     public FindCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_ROLE, PREFIX_COMPANY,
+                        PREFIX_DEADLINE, PREFIX_STATUS, PREFIX_JOB_TYPE, PREFIX_INDUSTRY);
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_ROLE, PREFIX_COMPANY,
+                PREFIX_DEADLINE, PREFIX_STATUS, PREFIX_JOB_TYPE, PREFIX_INDUSTRY);
+
+
+
+        ArrayList<FieldContainsKeywordsPredicate> predicateList = new ArrayList<>();
+
+        for (Map.Entry<Prefix, List<String>> entry : argMultimap.getArgMultimap().entrySet()) {
+            if (entry.getKey().equals(new Prefix(""))) {
+                continue;
+            }
+
+            if (!FieldContainsKeywordsPredicate.isValidPrefix(entry.getKey())) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, Messages.MESSAGE_INVALID_PREFIX));
+            }
+
+            String keywords = entry.getValue().get(0);
+            if (keywords.equals("")) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_EMPTY_KEYWORDS));
+            }
+
+            String[] splitKeywords = keywords.split("\\s+");
+            List<String> keywordList = new ArrayList<>();
+            for (String keyword : splitKeywords) {
+                keywordList.add(keyword);
+            }
+
+            FieldContainsKeywordsPredicate predicate = new FieldContainsKeywordsPredicate(entry.getKey(), keywordList);
+            predicateList.add(predicate);
+        }
+
+        if (argMultimap.size() < 2) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] specifierAndKeywords = trimmedArgs.split("\\s+");
-        List<String> keywords = getKeywordList(specifierAndKeywords);
-        String specifier = specifierAndKeywords[0];
-        if (!(FieldContainsKeywordsPredicate.isValidSpecifier(specifier))) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_INVALID_SPECIFIER));
-        }
-
-        return new FindCommand(new FieldContainsKeywordsPredicate(specifier, keywords));
-    }
-
-    /**
-     * Takes the given array of which contains the specifier and the keywords
-     * and returns a list of keywords.
-     */
-    private List<String> getKeywordList(String[] specifierAndKeywords) throws ParseException {
-        ArrayList<String> keywords = new ArrayList<>();
-        for (int i = 1; i < specifierAndKeywords.length; i++) {
-            keywords.add(specifierAndKeywords[i]);
-        }
-
-        return keywords;
+        return new FindCommand(new CombinedPredicate(predicateList));
     }
 
 }

--- a/src/main/java/seedu/application/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/application/logic/parser/SortCommandParser.java
@@ -30,11 +30,11 @@ public class SortCommandParser implements Parser<SortCommand> {
         }
 
         String specifier = splitArgs[0];
-        if (!(FieldComparator.isValidSpecifier(specifier))) {
+        if (!(FieldComparator.isValidPrefix(specifier))) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_INVALID_SPECIFIER));
         }
 
-        return new SortCommand(new FieldComparator(specifier));
+        return new SortCommand(new FieldComparator(new Prefix(specifier)));
     }
 }

--- a/src/main/java/seedu/application/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/application/logic/parser/SortCommandParser.java
@@ -2,38 +2,39 @@ package seedu.application.logic.parser;
 
 import static seedu.application.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import seedu.application.logic.commands.ListCommand;
+import seedu.application.logic.commands.SortCommand;
 import seedu.application.logic.parser.exceptions.ParseException;
 import seedu.application.model.job.FieldComparator;
 
 /**
  * Parses input arguments and creates a new ListCommand object
  */
-public class ListCommandParser implements Parser<ListCommand> {
+public class SortCommandParser implements Parser<SortCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the ListCommand
      * and returns a ListCommand object for execution.
      * @throws ParseException if the user input does not conform to the expected format.
      */
-    public ListCommand parse(String args) throws ParseException {
+    public SortCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
-            return new ListCommand(new FieldComparator(FieldComparator.EMPTY_COMPARATOR_SPECIFIER));
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
         }
 
         String[] splitArgs = trimmedArgs.split("\\s+");
         if (splitArgs.length > 1) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
         }
 
         String specifier = splitArgs[0];
         if (!(FieldComparator.isValidSpecifier(specifier))) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_INVALID_SPECIFIER));
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_INVALID_SPECIFIER));
         }
 
-        return new ListCommand(new FieldComparator(specifier));
+        return new SortCommand(new FieldComparator(specifier));
     }
 }

--- a/src/main/java/seedu/application/model/ApplicationBook.java
+++ b/src/main/java/seedu/application/model/ApplicationBook.java
@@ -96,13 +96,6 @@ public class ApplicationBook implements ReadOnlyApplicationBook {
     }
 
     /**
-     * Restores {@code jobs} to the original unsorted order.
-     */
-    public void unsortJobs() {
-        jobs.unsortJobs();
-    }
-
-    /**
      * Sorts the jobs in the application book based on the comparator provided.
      * @param comparator The comparator used to compare 2 jobs.
      */

--- a/src/main/java/seedu/application/model/Model.java
+++ b/src/main/java/seedu/application/model/Model.java
@@ -87,11 +87,6 @@ public interface Model {
     void updateFilteredJobList(Predicate<Job> predicate);
 
     /**
-     * Restores the jobs in application book to the original unsorted order.
-     */
-    public void unsortJobs();
-
-    /**
      * Sorts the jobs in the application book based on the comparator provided.
      * @param comparator The comparator used to compare 2 jobs.
      */

--- a/src/main/java/seedu/application/model/ModelManager.java
+++ b/src/main/java/seedu/application/model/ModelManager.java
@@ -132,11 +132,6 @@ public class ModelManager implements Model {
     //=========== Sorted Job List Accessors =============================================================
 
     @Override
-    public void unsortJobs() {
-        applicationBook.unsortJobs();
-    }
-
-    @Override
     public void sortJobs(FieldComparator comparator) {
         applicationBook.sortJobs(comparator);
     }

--- a/src/main/java/seedu/application/model/job/CombinedPredicate.java
+++ b/src/main/java/seedu/application/model/job/CombinedPredicate.java
@@ -1,0 +1,41 @@
+package seedu.application.model.job;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Represents a predicate that is the logical AND of all {@code FieldContainsKeyWordsPredicate} objects supplied to it.
+ */
+public class CombinedPredicate implements Predicate<Job> {
+    private List<FieldContainsKeywordsPredicate> predicateList;
+
+    public CombinedPredicate(List<FieldContainsKeywordsPredicate> predicateList) {
+        this.predicateList = new ArrayList<>(predicateList);
+    }
+
+    @Override
+    public boolean test(Job job) {
+        Predicate<Job> predicate = x -> true;
+        for (Predicate<Job> p : predicateList) {
+            predicate = predicate.and(p);
+        }
+        return predicate.test(job);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof CombinedPredicate)) {
+            return false;
+        }
+
+        CombinedPredicate otherCombinedPredicate = (CombinedPredicate) other;
+        return predicateList.equals(otherCombinedPredicate.predicateList);
+    }
+
+}

--- a/src/main/java/seedu/application/model/job/Company.java
+++ b/src/main/java/seedu/application/model/job/Company.java
@@ -9,7 +9,7 @@ import seedu.application.commons.util.AppUtil;
  * Guarantees: immutable; is valid as declared in {@link #isValidCompany(String)}
  */
 public class Company {
-    public static final String COMPANY_SPECIFIER = "-c";
+
     public static final String MESSAGE_CONSTRAINTS =
             "Company names should adhere to the following constraints:\n"
                     + "1. Start with an alphanumeric character\n"

--- a/src/main/java/seedu/application/model/job/Deadline.java
+++ b/src/main/java/seedu/application/model/job/Deadline.java
@@ -13,7 +13,6 @@ import seedu.application.commons.util.AppUtil;
  */
 public class Deadline {
 
-    public static final String DEADLINE_SPECIFIER = "-d";
     public static final String MESSAGE_CONSTRAINTS =
         "Deadline should be in valid DateTime format: "
             + "MMM dd yyyy HHmm\n"

--- a/src/main/java/seedu/application/model/job/FieldComparator.java
+++ b/src/main/java/seedu/application/model/job/FieldComparator.java
@@ -2,6 +2,8 @@ package seedu.application.model.job;
 
 import static seedu.application.model.job.Company.COMPANY_SPECIFIER;
 import static seedu.application.model.job.Deadline.DEADLINE_SPECIFIER;
+import static seedu.application.model.job.Industry.INDUSTRY_SPECIFIER;
+import static seedu.application.model.job.JobType.JOB_TYPE_SPECIFIER;
 import static seedu.application.model.job.Role.ROLE_SPECIFIER;
 import static seedu.application.model.job.Status.STATUS_SPECIFIER;
 
@@ -30,8 +32,11 @@ public class FieldComparator implements Comparator<Job> {
         return specifier.equals(EMPTY_COMPARATOR_SPECIFIER)
                 || specifier.equals(COMPANY_SPECIFIER)
                 || specifier.equals(ROLE_SPECIFIER)
+                || specifier.equals(STATUS_SPECIFIER)
+                || specifier.equals(INDUSTRY_SPECIFIER)
                 || specifier.equals(DEADLINE_SPECIFIER)
-                || specifier.equals(STATUS_SPECIFIER);
+                || specifier.equals(JOB_TYPE_SPECIFIER);
+
     }
 
     /**

--- a/src/main/java/seedu/application/model/job/FieldComparator.java
+++ b/src/main/java/seedu/application/model/job/FieldComparator.java
@@ -1,65 +1,71 @@
 package seedu.application.model.job;
 
-import static seedu.application.model.job.Company.COMPANY_SPECIFIER;
-import static seedu.application.model.job.Deadline.DEADLINE_SPECIFIER;
-import static seedu.application.model.job.Industry.INDUSTRY_SPECIFIER;
-import static seedu.application.model.job.JobType.JOB_TYPE_SPECIFIER;
-import static seedu.application.model.job.Role.ROLE_SPECIFIER;
-import static seedu.application.model.job.Status.STATUS_SPECIFIER;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_COMPANY;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_DEADLINE;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_INDUSTRY;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_JOB_TYPE;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_STATUS;
 
 import java.util.Comparator;
+
+import seedu.application.logic.parser.Prefix;
 
 /**
  * Compares two jobs based on the field specifier provided.
  */
 public class FieldComparator implements Comparator<Job> {
-    public static final String EMPTY_COMPARATOR_SPECIFIER = "";
-    private final String specifier;
+    private final Prefix prefix;
 
     /**
      * Constructs a {@code FieldComparator} using the specifier given.
-     * @param specifier String denoting which field to sort by.
+     * @param prefix String denoting which field to sort by.
      */
-    public FieldComparator(String specifier) {
-        this.specifier = specifier;
+    public FieldComparator(Prefix prefix) {
+        this.prefix = prefix;
     }
 
     /**
      * Checks if a {@code String} is a valid specifier.
-     * @param specifier The user String input.
+     * @param prefix The user String input.
      */
-    public static boolean isValidSpecifier(String specifier) {
-        return specifier.equals(EMPTY_COMPARATOR_SPECIFIER)
-                || specifier.equals(COMPANY_SPECIFIER)
-                || specifier.equals(ROLE_SPECIFIER)
-                || specifier.equals(STATUS_SPECIFIER)
-                || specifier.equals(INDUSTRY_SPECIFIER)
-                || specifier.equals(DEADLINE_SPECIFIER)
-                || specifier.equals(JOB_TYPE_SPECIFIER);
+    public static boolean isValidPrefix(String prefix) {
+        return prefix.equals(PREFIX_COMPANY.getPrefix())
+                || prefix.equals(PREFIX_ROLE.getPrefix())
+                || prefix.equals(PREFIX_STATUS.getPrefix())
+                || prefix.equals(PREFIX_INDUSTRY.getPrefix())
+                || prefix.equals(PREFIX_DEADLINE.getPrefix())
+                || prefix.equals(PREFIX_JOB_TYPE.getPrefix());
 
-    }
-
-    /**
-     * Checks if the comparator contains a specifier.
-     */
-    public boolean hasSpecifier() {
-        return !specifier.equals(EMPTY_COMPARATOR_SPECIFIER);
     }
 
     @Override
     public int compare(Job job1, Job job2) {
-        switch (specifier) {
-        case COMPANY_SPECIFIER:
+        if (prefix.equals(PREFIX_COMPANY)) {
             return job1.getCompany().name.compareToIgnoreCase(job2.getCompany().name);
-        case ROLE_SPECIFIER:
-            return job1.getRole().description.compareToIgnoreCase(job2.getRole().description);
-        case DEADLINE_SPECIFIER:
-            return job1.getDeadline().compareTo(job2.getDeadline());
-        case STATUS_SPECIFIER:
-            return job1.getStatus().status.compareToIgnoreCase(job2.getStatus().status);
-        default:
-            return -1;
         }
+
+        if (prefix.equals(PREFIX_ROLE)) {
+            return job1.getRole().description.compareToIgnoreCase(job2.getRole().description);
+        }
+
+        if (prefix.equals(PREFIX_STATUS)) {
+            return job1.getStatus().status.compareToIgnoreCase(job2.getStatus().status);
+        }
+
+        if (prefix.equals(PREFIX_INDUSTRY)) {
+            return job1.getIndustry().industry.compareToIgnoreCase(job2.getIndustry().industry);
+        }
+
+        if (prefix.equals(PREFIX_DEADLINE)) {
+            return job1.getDeadline().compareTo(job2.getDeadline());
+        }
+
+        if (prefix.equals(PREFIX_JOB_TYPE)) {
+            return job1.getJobType().jobType.compareToIgnoreCase(job2.getJobType().jobType);
+        }
+
+        return -1;
     }
 
     @Override
@@ -73,7 +79,7 @@ public class FieldComparator implements Comparator<Job> {
             return false;
         }
 
-        FieldComparator otherSpecifier = (FieldComparator) other;
-        return specifier.equals(otherSpecifier.specifier);
+        FieldComparator otherComparator = (FieldComparator) other;
+        return prefix.equals(otherComparator.prefix);
     }
 }

--- a/src/main/java/seedu/application/model/job/FieldContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/application/model/job/FieldContainsKeywordsPredicate.java
@@ -1,55 +1,75 @@
 package seedu.application.model.job;
 
-import static seedu.application.model.job.Company.COMPANY_SPECIFIER;
-import static seedu.application.model.job.Role.ROLE_SPECIFIER;
-
 import java.util.List;
 import java.util.function.Predicate;
 
 import seedu.application.commons.util.StringUtil;
 import seedu.application.commons.util.ToStringBuilder;
+import seedu.application.logic.parser.CliSyntax;
+import seedu.application.logic.parser.Prefix;
 
 /**
  * Tests that a {@code Job}'s field matches any of the keywords given.
  */
 public class FieldContainsKeywordsPredicate implements Predicate<Job> {
-    private final String specifier;
+    private final Prefix prefix;
     private final List<String> keywords;
 
     /**
-     * Constructs a {@code FieldContainsKeywordsPredicate} using the specifier and keywords given.
-     * @param specifier String denoting which field to search in.
+     * Constructs a {@code FieldContainsKeywordsPredicate} using the prefix and keywords given.
+     * @param prefix Prefix denoting which field to search in.
      * @param keywords List of keywords which the user is searching for.
      */
-    public FieldContainsKeywordsPredicate(String specifier, List<String> keywords) {
-        this.specifier = specifier;
+    public FieldContainsKeywordsPredicate(Prefix prefix, List<String> keywords) {
+        this.prefix = prefix;
         this.keywords = keywords;
     }
 
     private String getField(Job job) {
-        switch (specifier) {
-        case COMPANY_SPECIFIER:
+        if (prefix.equals(CliSyntax.PREFIX_COMPANY)) {
             return job.getCompany().name;
-        case ROLE_SPECIFIER:
-            return job.getRole().description;
-        default:
-            return null;
         }
+
+        if (prefix.equals(CliSyntax.PREFIX_ROLE)) {
+            return job.getRole().description;
+        }
+
+        if (prefix.equals(CliSyntax.PREFIX_STATUS)) {
+            return job.getStatus().status;
+        }
+
+        if (prefix.equals(CliSyntax.PREFIX_INDUSTRY)) {
+            return job.getIndustry().industry;
+        }
+
+        if (prefix.equals(CliSyntax.PREFIX_DEADLINE)) {
+            return job.getDeadline().deadline;
+        }
+
+        if (prefix.equals(CliSyntax.PREFIX_JOB_TYPE)) {
+            return job.getJobType().jobType;
+        }
+
+        return null;
     }
 
     /**
-     * Checks if a {@code String} is a valid specifier.
-     * @param specifier The user String input.
+     * Checks if a {@code Prefix} is a valid prefix in the context of the Find command.
+     * @param prefix The prefix specified by the user.
      */
-    public static boolean isValidSpecifier(String specifier) {
-        return specifier.equals(COMPANY_SPECIFIER)
-                || specifier.equals(ROLE_SPECIFIER);
+    public static boolean isValidPrefix(Prefix prefix) {
+        return prefix.equals(CliSyntax.PREFIX_COMPANY)
+                || prefix.equals(CliSyntax.PREFIX_ROLE)
+                || prefix.equals(CliSyntax.PREFIX_STATUS)
+                || prefix.equals(CliSyntax.PREFIX_INDUSTRY)
+                || prefix.equals(CliSyntax.PREFIX_DEADLINE)
+                || prefix.equals(CliSyntax.PREFIX_JOB_TYPE);
     }
 
     @Override
     public boolean test(Job job) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(getField(job), keyword));
+                .allMatch(keyword -> StringUtil.containsWordIgnoreCase(getField(job), keyword));
     }
 
     @Override
@@ -64,7 +84,7 @@ public class FieldContainsKeywordsPredicate implements Predicate<Job> {
         }
 
         FieldContainsKeywordsPredicate otherFieldContainsKeywordsPredicate = (FieldContainsKeywordsPredicate) other;
-        return specifier.equals(otherFieldContainsKeywordsPredicate.specifier)
+        return prefix.equals(otherFieldContainsKeywordsPredicate.prefix)
                 && keywords.equals(otherFieldContainsKeywordsPredicate.keywords);
     }
 

--- a/src/main/java/seedu/application/model/job/Industry.java
+++ b/src/main/java/seedu/application/model/job/Industry.java
@@ -9,6 +9,7 @@ import seedu.application.commons.util.AppUtil;
  */
 
 public class Industry {
+    public static final String INDUSTRY_SPECIFIER = "-i";
     public static final String MESSAGE_CONSTRAINTS =
             "Industry descriptions should adhere to the following constraints:\n"
                     + "1. Only contain alphanumeric characters and spaces\n";

--- a/src/main/java/seedu/application/model/job/Industry.java
+++ b/src/main/java/seedu/application/model/job/Industry.java
@@ -9,7 +9,7 @@ import seedu.application.commons.util.AppUtil;
  */
 
 public class Industry {
-    public static final String INDUSTRY_SPECIFIER = "-i";
+
     public static final String MESSAGE_CONSTRAINTS =
             "Industry descriptions should adhere to the following constraints:\n"
                     + "1. Only contain alphanumeric characters and spaces\n";

--- a/src/main/java/seedu/application/model/job/JobType.java
+++ b/src/main/java/seedu/application/model/job/JobType.java
@@ -10,7 +10,6 @@ import seedu.application.commons.util.AppUtil;
  */
 public class JobType {
 
-    public static final String JOB_TYPE_SPECIFIER = "-t";
     public static final String MESSAGE_CONSTRAINTS =
             "Type is not case sensitive and should only be in the form: \n"
                     + "FULL_TIME, PART_TIME, INTERNSHIP, TEMPORARY, CONTRACT, FREELANCE, VOLUNTEER";

--- a/src/main/java/seedu/application/model/job/JobType.java
+++ b/src/main/java/seedu/application/model/job/JobType.java
@@ -10,6 +10,7 @@ import seedu.application.commons.util.AppUtil;
  */
 public class JobType {
 
+    public static final String JOB_TYPE_SPECIFIER = "-t";
     public static final String MESSAGE_CONSTRAINTS =
             "Type is not case sensitive and should only be in the form: \n"
                     + "FULL_TIME, PART_TIME, INTERNSHIP, TEMPORARY, CONTRACT, FREELANCE, VOLUNTEER";

--- a/src/main/java/seedu/application/model/job/Role.java
+++ b/src/main/java/seedu/application/model/job/Role.java
@@ -10,7 +10,6 @@ import seedu.application.commons.util.AppUtil;
  */
 public class Role {
 
-    public static final String ROLE_SPECIFIER = "-r";
     public static final String MESSAGE_CONSTRAINTS =
             "Role descriptions should adhere to the following constraints:\n"
                     + "1. Only contain alphanumeric characters and spaces\n"

--- a/src/main/java/seedu/application/model/job/Status.java
+++ b/src/main/java/seedu/application/model/job/Status.java
@@ -9,7 +9,6 @@ import seedu.application.commons.util.AppUtil;
  */
 public class Status {
 
-    public static final String STATUS_SPECIFIER = "-s";
     public static final String MESSAGE_CONSTRAINTS =
             "Status is not case sensitive and should only be in the form: TO_BE_SUBMITTED, PENDING, APPROVED, REJECTED";
 

--- a/src/main/java/seedu/application/model/job/UniqueJobList.java
+++ b/src/main/java/seedu/application/model/job/UniqueJobList.java
@@ -97,10 +97,6 @@ public class UniqueJobList implements Iterable<Job> {
         internalList.setAll(jobs);
     }
 
-    public void unsortJobs() {
-
-    }
-
     /**
      * Sorts the jobs in the application book based on the comparator provided.
      * @param comparator The comparator used to compare 2 jobs.

--- a/src/test/java/seedu/application/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/application/logic/LogicManagerTest.java
@@ -64,7 +64,8 @@ public class LogicManagerTest {
     @Test
     public void execute_validCommand_success() throws Exception {
         String listCommand = ListCommand.COMMAND_WORD;
-        assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);
+        String expectedMessage = String.format(ListCommand.MESSAGE_SUCCESS, 0);
+        assertCommandSuccess(listCommand, expectedMessage, model);
     }
 
     @Test

--- a/src/test/java/seedu/application/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/application/logic/commands/AddCommandTest.java
@@ -158,11 +158,6 @@ public class AddCommandTest {
         }
 
         @Override
-        public void unsortJobs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
         public void sortJobs(FieldComparator comparator) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/application/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/application/logic/commands/CommandTestUtil.java
@@ -8,7 +8,6 @@ import static seedu.application.logic.parser.CliSyntax.PREFIX_INDUSTRY;
 import static seedu.application.logic.parser.CliSyntax.PREFIX_JOB_TYPE;
 import static seedu.application.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.application.logic.parser.CliSyntax.PREFIX_STATUS;
-import static seedu.application.model.job.Role.ROLE_SPECIFIER;
 import static seedu.application.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
@@ -127,7 +126,7 @@ public class CommandTestUtil {
         Job job = model.getFilteredJobList().get(targetIndex.getZeroBased());
         final String[] splitRole = job.getRole().description.split("\\s+");
         model.updateFilteredJobList(
-            new FieldContainsKeywordsPredicate(ROLE_SPECIFIER, Arrays.asList(splitRole[0])));
+            new FieldContainsKeywordsPredicate(PREFIX_ROLE, Arrays.asList(splitRole)));
 
         assertEquals(1, model.getFilteredJobList().size());
     }

--- a/src/test/java/seedu/application/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/application/logic/commands/FindCommandTest.java
@@ -4,10 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.application.logic.Messages.MESSAGE_JOBS_LISTED_OVERVIEW;
 import static seedu.application.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.application.model.job.Role.ROLE_SPECIFIER;
-import static seedu.application.testutil.TypicalJobs.FRUIT_SELLER;
-import static seedu.application.testutil.TypicalJobs.GRASS_CUTTER;
-import static seedu.application.testutil.TypicalJobs.POLICE_OFFICER;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.application.testutil.TypicalJobs.getTypicalApplicationBook;
 
 import java.util.ArrayList;
@@ -19,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import seedu.application.model.Model;
 import seedu.application.model.ModelManager;
 import seedu.application.model.UserPrefs;
+import seedu.application.model.job.CombinedPredicate;
 import seedu.application.model.job.FieldContainsKeywordsPredicate;
 
 /**
@@ -30,10 +28,12 @@ public class FindCommandTest {
 
     @Test
     public void equals() {
-        FieldContainsKeywordsPredicate firstPredicate =
-                new FieldContainsKeywordsPredicate(ROLE_SPECIFIER, Collections.singletonList("first"));
-        FieldContainsKeywordsPredicate secondPredicate =
-                new FieldContainsKeywordsPredicate(ROLE_SPECIFIER, Collections.singletonList("second"));
+        CombinedPredicate firstPredicate =
+                new CombinedPredicate(Arrays.asList(
+                        new FieldContainsKeywordsPredicate(PREFIX_ROLE, Collections.singletonList("first"))));
+        CombinedPredicate secondPredicate =
+                new CombinedPredicate(Arrays.asList(
+                        new FieldContainsKeywordsPredicate(PREFIX_ROLE, Collections.singletonList("second"))));
 
         FindCommand findFirstCommand = new FindCommand(firstPredicate);
         FindCommand findSecondCommand = new FindCommand(secondPredicate);
@@ -56,29 +56,20 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_zeroKeywords_noJobFound() {
+    public void execute_multipleKeywords_noJobsFound() {
         String expectedMessage = String.format(MESSAGE_JOBS_LISTED_OVERVIEW, 0);
-        FieldContainsKeywordsPredicate predicate = preparePredicate(ROLE_SPECIFIER + " ");
-        FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredJobList(predicate);
+        CombinedPredicate combinedPredicate = new CombinedPredicate(
+                Arrays.asList(preparePredicate(PREFIX_ROLE + " Grass Seller Police")));
+        FindCommand command = new FindCommand(combinedPredicate);
+        expectedModel.updateFilteredJobList(combinedPredicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredJobList());
-    }
-
-    @Test
-    public void execute_multipleKeywords_multipleJobsFound() {
-        String expectedMessage = String.format(MESSAGE_JOBS_LISTED_OVERVIEW, 3);
-        FieldContainsKeywordsPredicate predicate = preparePredicate(ROLE_SPECIFIER + " Grass Seller Police");
-        FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredJobList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(POLICE_OFFICER, FRUIT_SELLER, GRASS_CUTTER), model.getFilteredJobList());
+        assertEquals(Arrays.asList(), model.getFilteredJobList());
     }
 
     @Test
     public void toStringMethod() {
-        FieldContainsKeywordsPredicate predicate =
-                new FieldContainsKeywordsPredicate(ROLE_SPECIFIER, Arrays.asList("keyword"));
+        CombinedPredicate predicate = new CombinedPredicate(Arrays.asList(
+                        new FieldContainsKeywordsPredicate(PREFIX_ROLE, Arrays.asList("keyword"))));
         FindCommand findCommand = new FindCommand(predicate);
         String expected = FindCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
         assertEquals(expected, findCommand.toString());
@@ -89,9 +80,8 @@ public class FindCommandTest {
      */
     private FieldContainsKeywordsPredicate preparePredicate(String userInput) {
         String[] specifierAndKeywords = userInput.split("\\s+");
-        String specifier = specifierAndKeywords[0];
         ArrayList<String> keywords = new ArrayList<>(Arrays.asList(specifierAndKeywords)
                 .subList(1, specifierAndKeywords.length));
-        return new FieldContainsKeywordsPredicate(specifier, keywords);
+        return new FieldContainsKeywordsPredicate(PREFIX_ROLE, keywords);
     }
 }

--- a/src/test/java/seedu/application/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/application/logic/commands/ListCommandTest.java
@@ -1,11 +1,7 @@
 package seedu.application.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.application.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.application.logic.commands.CommandTestUtil.showJobAtIndex;
-import static seedu.application.model.job.Company.COMPANY_SPECIFIER;
-import static seedu.application.model.job.Role.ROLE_SPECIFIER;
 import static seedu.application.testutil.TypicalIndexes.INDEX_FIRST_JOB;
 import static seedu.application.testutil.TypicalJobs.getTypicalApplicationBook;
 
@@ -15,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import seedu.application.model.Model;
 import seedu.application.model.ModelManager;
 import seedu.application.model.UserPrefs;
-import seedu.application.model.job.*;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
@@ -33,64 +28,14 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(new FieldComparator(FieldComparator.EMPTY_COMPARATOR_SPECIFIER)),
-            model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        String expectedMessage = String.format(ListCommand.MESSAGE_SUCCESS, 7);
+        assertCommandSuccess(new ListCommand(), model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showJobAtIndex(model, INDEX_FIRST_JOB);
-        assertCommandSuccess(new ListCommand(new FieldComparator(FieldComparator.EMPTY_COMPARATOR_SPECIFIER)),
-            model, ListCommand.MESSAGE_SUCCESS, expectedModel);
-    }
-
-    @Test
-    public void execute_listIsSortedByRoles_showsSortedListByRoles() {
-        FieldComparator fieldComparator = new FieldComparator(ROLE_SPECIFIER);
-        expectedModel.sortJobs(fieldComparator);
-        assertCommandSuccess(new ListCommand(fieldComparator), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
-    }
-
-    @Test
-    public void execute_listIsSortedByCompany_showsSortedListByCompany() {
-        FieldComparator fieldComparator = new FieldComparator(COMPANY_SPECIFIER);
-        expectedModel.sortJobs(fieldComparator);
-        assertCommandSuccess(new ListCommand(fieldComparator), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
-    }
-
-    @Test
-    public void execute_listIsSortedByDeadline_showsSortedListByDeadline() {
-        FieldComparator fieldComparator = new FieldComparator(Deadline.DEADLINE_SPECIFIER);
-        expectedModel.sortJobs(fieldComparator);
-        assertCommandSuccess(new ListCommand(fieldComparator), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
-    }
-
-    @Test
-    public void execute_listIsSortedByStatus_showsSortedListByStatus() {
-        FieldComparator fieldComparator = new FieldComparator(Status.STATUS_SPECIFIER);
-        expectedModel.sortJobs(fieldComparator);
-        assertCommandSuccess(new ListCommand(fieldComparator), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
-    }
-
-    @Test
-    public void equals() {
-        ListCommand listByRoleCommand = new ListCommand(new FieldComparator(ROLE_SPECIFIER));
-
-        // same object -> returns true
-        assertEquals(listByRoleCommand, listByRoleCommand);
-
-        // same values -> returns true
-        ListCommand listByRoleCommandCopy = new ListCommand(new FieldComparator(ROLE_SPECIFIER));
-        assertEquals(listByRoleCommand, listByRoleCommandCopy);
-
-        // different types -> returns false
-        assertNotEquals(listByRoleCommand, 5.0f);
-
-        // null -> returns false
-        assertNotEquals(listByRoleCommand, null);
-
-        // different person -> returns false
-        ListCommand listByCompanyCommand = new ListCommand(new FieldComparator(COMPANY_SPECIFIER));
-        assertNotEquals(listByRoleCommand, listByCompanyCommand);
+        String expectedMessage = String.format(ListCommand.MESSAGE_SUCCESS, 7);
+        assertCommandSuccess(new ListCommand(), model, expectedMessage, expectedModel);
     }
 }

--- a/src/test/java/seedu/application/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/application/logic/commands/SortCommandTest.java
@@ -1,0 +1,81 @@
+package seedu.application.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.application.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.application.model.job.Company.COMPANY_SPECIFIER;
+import static seedu.application.model.job.Role.ROLE_SPECIFIER;
+import static seedu.application.testutil.TypicalJobs.getTypicalApplicationBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.application.model.Model;
+import seedu.application.model.ModelManager;
+import seedu.application.model.UserPrefs;
+import seedu.application.model.job.*;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for SortCommand.
+ */
+public class SortCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalApplicationBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getApplicationBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_listIsSortedByRoles_showsSortedListByRole() {
+        FieldComparator fieldComparator = new FieldComparator(ROLE_SPECIFIER);
+        expectedModel.sortJobs(fieldComparator);
+        assertCommandSuccess(new SortCommand(fieldComparator), model, SortCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_listIsSortedByCompany_showsSortedListByCompany() {
+        FieldComparator fieldComparator = new FieldComparator(COMPANY_SPECIFIER);
+        expectedModel.sortJobs(fieldComparator);
+        assertCommandSuccess(new SortCommand(fieldComparator), model, SortCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_listIsSortedByDeadline_showsSortedListByDeadline() {
+        FieldComparator fieldComparator = new FieldComparator(Deadline.DEADLINE_SPECIFIER);
+        expectedModel.sortJobs(fieldComparator);
+        assertCommandSuccess(new SortCommand(fieldComparator), model, SortCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_listIsSortedByStatus_showsSortedListByStatus() {
+        FieldComparator fieldComparator = new FieldComparator(Status.STATUS_SPECIFIER);
+        expectedModel.sortJobs(fieldComparator);
+        assertCommandSuccess(new SortCommand(fieldComparator), model, SortCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void equals() {
+        SortCommand listByRoleCommand = new SortCommand(new FieldComparator(ROLE_SPECIFIER));
+
+        // same object -> returns true
+        assertEquals(listByRoleCommand, listByRoleCommand);
+
+        // same values -> returns true
+        SortCommand listByRoleCommandCopy = new SortCommand(new FieldComparator(ROLE_SPECIFIER));
+        assertEquals(listByRoleCommand, listByRoleCommandCopy);
+
+        // different types -> returns false
+        assertNotEquals(listByRoleCommand, 5.0f);
+
+        // null -> returns false
+        assertNotEquals(listByRoleCommand, null);
+
+        // different person -> returns false
+        SortCommand listByCompanyCommand = new SortCommand(new FieldComparator(COMPANY_SPECIFIER));
+        assertNotEquals(listByRoleCommand, listByCompanyCommand);
+    }
+}

--- a/src/test/java/seedu/application/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/application/logic/commands/SortCommandTest.java
@@ -3,8 +3,12 @@ package seedu.application.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.application.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.application.model.job.Company.COMPANY_SPECIFIER;
-import static seedu.application.model.job.Role.ROLE_SPECIFIER;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_COMPANY;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_DEADLINE;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_INDUSTRY;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_JOB_TYPE;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.application.testutil.TypicalJobs.getTypicalApplicationBook;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -13,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import seedu.application.model.Model;
 import seedu.application.model.ModelManager;
 import seedu.application.model.UserPrefs;
-import seedu.application.model.job.*;
+import seedu.application.model.job.FieldComparator;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for SortCommand.
@@ -30,42 +34,56 @@ public class SortCommandTest {
     }
 
     @Test
-    public void execute_listIsSortedByRoles_showsSortedListByRole() {
-        FieldComparator fieldComparator = new FieldComparator(ROLE_SPECIFIER);
-        expectedModel.sortJobs(fieldComparator);
-        assertCommandSuccess(new SortCommand(fieldComparator), model, SortCommand.MESSAGE_SUCCESS, expectedModel);
-    }
-
-    @Test
     public void execute_listIsSortedByCompany_showsSortedListByCompany() {
-        FieldComparator fieldComparator = new FieldComparator(COMPANY_SPECIFIER);
+        FieldComparator fieldComparator = new FieldComparator(PREFIX_COMPANY);
         expectedModel.sortJobs(fieldComparator);
         assertCommandSuccess(new SortCommand(fieldComparator), model, SortCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
-    public void execute_listIsSortedByDeadline_showsSortedListByDeadline() {
-        FieldComparator fieldComparator = new FieldComparator(Deadline.DEADLINE_SPECIFIER);
+    public void execute_listIsSortedByRoles_showsSortedListByRole() {
+        FieldComparator fieldComparator = new FieldComparator(PREFIX_ROLE);
         expectedModel.sortJobs(fieldComparator);
         assertCommandSuccess(new SortCommand(fieldComparator), model, SortCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_listIsSortedByStatus_showsSortedListByStatus() {
-        FieldComparator fieldComparator = new FieldComparator(Status.STATUS_SPECIFIER);
+        FieldComparator fieldComparator = new FieldComparator(PREFIX_STATUS);
+        expectedModel.sortJobs(fieldComparator);
+        assertCommandSuccess(new SortCommand(fieldComparator), model, SortCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_listIsSortedByIndustry_showsSortedListByIndustry() {
+        FieldComparator fieldComparator = new FieldComparator(PREFIX_INDUSTRY);
+        expectedModel.sortJobs(fieldComparator);
+        assertCommandSuccess(new SortCommand(fieldComparator), model, SortCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_listIsSortedByDeadline_showsSortedListByDeadline() {
+        FieldComparator fieldComparator = new FieldComparator(PREFIX_DEADLINE);
+        expectedModel.sortJobs(fieldComparator);
+        assertCommandSuccess(new SortCommand(fieldComparator), model, SortCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_listIsSortedByJobType_showsSortedListByJobType() {
+        FieldComparator fieldComparator = new FieldComparator(PREFIX_JOB_TYPE);
         expectedModel.sortJobs(fieldComparator);
         assertCommandSuccess(new SortCommand(fieldComparator), model, SortCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void equals() {
-        SortCommand listByRoleCommand = new SortCommand(new FieldComparator(ROLE_SPECIFIER));
+        SortCommand listByRoleCommand = new SortCommand(new FieldComparator(PREFIX_ROLE));
 
         // same object -> returns true
         assertEquals(listByRoleCommand, listByRoleCommand);
 
         // same values -> returns true
-        SortCommand listByRoleCommandCopy = new SortCommand(new FieldComparator(ROLE_SPECIFIER));
+        SortCommand listByRoleCommandCopy = new SortCommand(new FieldComparator(PREFIX_ROLE));
         assertEquals(listByRoleCommand, listByRoleCommandCopy);
 
         // different types -> returns false
@@ -75,7 +93,7 @@ public class SortCommandTest {
         assertNotEquals(listByRoleCommand, null);
 
         // different person -> returns false
-        SortCommand listByCompanyCommand = new SortCommand(new FieldComparator(COMPANY_SPECIFIER));
+        SortCommand listByCompanyCommand = new SortCommand(new FieldComparator(PREFIX_COMPANY));
         assertNotEquals(listByRoleCommand, listByCompanyCommand);
     }
 }

--- a/src/test/java/seedu/application/logic/parser/ApplicationBookParserTest.java
+++ b/src/test/java/seedu/application/logic/parser/ApplicationBookParserTest.java
@@ -4,10 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.application.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.application.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
-import static seedu.application.model.job.Company.COMPANY_SPECIFIER;
-import static seedu.application.model.job.Deadline.DEADLINE_SPECIFIER;
-import static seedu.application.model.job.Role.ROLE_SPECIFIER;
-import static seedu.application.model.job.Status.STATUS_SPECIFIER;
+import static seedu.application.logic.parser.CliSyntax.*;
 import static seedu.application.testutil.Assert.assertThrows;
 import static seedu.application.testutil.TypicalIndexes.INDEX_FIRST_JOB;
 
@@ -17,18 +14,11 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.application.logic.commands.AddCommand;
-import seedu.application.logic.commands.ClearCommand;
-import seedu.application.logic.commands.DeleteCommand;
-import seedu.application.logic.commands.EditCommand;
+import seedu.application.logic.commands.*;
 import seedu.application.logic.commands.EditCommand.EditJobDescriptor;
-import seedu.application.logic.commands.ExitCommand;
-import seedu.application.logic.commands.FindCommand;
-import seedu.application.logic.commands.HelpCommand;
-import seedu.application.logic.commands.ListCommand;
+import seedu.application.logic.commands.SortCommand;
 import seedu.application.logic.parser.exceptions.ParseException;
-import seedu.application.model.job.FieldContainsKeywordsPredicate;
-import seedu.application.model.job.Job;
+import seedu.application.model.job.*;
 import seedu.application.testutil.EditJobDescriptorBuilder;
 import seedu.application.testutil.JobBuilder;
 import seedu.application.testutil.JobUtil;
@@ -76,9 +66,11 @@ public class ApplicationBookParserTest {
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
-            FindCommand.COMMAND_WORD + " " + ROLE_SPECIFIER
+            FindCommand.COMMAND_WORD + " " + PREFIX_ROLE
                 + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new FieldContainsKeywordsPredicate(ROLE_SPECIFIER, keywords)), command);
+        FieldContainsKeywordsPredicate fieldPredicate = new FieldContainsKeywordsPredicate(PREFIX_ROLE, keywords);
+        CombinedPredicate combinedPredicate = new CombinedPredicate(List.of(fieldPredicate));
+        assertEquals(new FindCommand(combinedPredicate), command);
     }
 
     @Test
@@ -88,12 +80,19 @@ public class ApplicationBookParserTest {
     }
 
     @Test
-    public void parseCommand_list() throws Exception {
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " " + COMPANY_SPECIFIER) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " " + ROLE_SPECIFIER) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " " + DEADLINE_SPECIFIER) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " " + STATUS_SPECIFIER) instanceof ListCommand);
+    public void parseCommand_sort() throws Exception {
+        assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD + " "
+                + Company.COMPANY_SPECIFIER) instanceof SortCommand);
+        assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD + " "
+                + Role.ROLE_SPECIFIER) instanceof SortCommand);
+        assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD + " "
+                + Status.STATUS_SPECIFIER) instanceof SortCommand);
+        assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD + " "
+                + Industry.INDUSTRY_SPECIFIER) instanceof SortCommand);
+        assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD + " "
+                + Deadline.DEADLINE_SPECIFIER) instanceof SortCommand);
+        assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD + " "
+                + JobType.JOB_TYPE_SPECIFIER) instanceof SortCommand);
     }
 
     @Test

--- a/src/test/java/seedu/application/logic/parser/ApplicationBookParserTest.java
+++ b/src/test/java/seedu/application/logic/parser/ApplicationBookParserTest.java
@@ -18,7 +18,9 @@ import seedu.application.logic.commands.*;
 import seedu.application.logic.commands.EditCommand.EditJobDescriptor;
 import seedu.application.logic.commands.SortCommand;
 import seedu.application.logic.parser.exceptions.ParseException;
-import seedu.application.model.job.*;
+import seedu.application.model.job.CombinedPredicate;
+import seedu.application.model.job.FieldContainsKeywordsPredicate;
+import seedu.application.model.job.Job;
 import seedu.application.testutil.EditJobDescriptorBuilder;
 import seedu.application.testutil.JobBuilder;
 import seedu.application.testutil.JobUtil;
@@ -82,17 +84,17 @@ public class ApplicationBookParserTest {
     @Test
     public void parseCommand_sort() throws Exception {
         assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD + " "
-                + Company.COMPANY_SPECIFIER) instanceof SortCommand);
+                + PREFIX_COMPANY) instanceof SortCommand);
         assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD + " "
-                + Role.ROLE_SPECIFIER) instanceof SortCommand);
+                + PREFIX_ROLE) instanceof SortCommand);
         assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD + " "
-                + Status.STATUS_SPECIFIER) instanceof SortCommand);
+                + PREFIX_STATUS) instanceof SortCommand);
         assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD + " "
-                + Industry.INDUSTRY_SPECIFIER) instanceof SortCommand);
+                + PREFIX_INDUSTRY) instanceof SortCommand);
         assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD + " "
-                + Deadline.DEADLINE_SPECIFIER) instanceof SortCommand);
+                + PREFIX_DEADLINE) instanceof SortCommand);
         assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD + " "
-                + JobType.JOB_TYPE_SPECIFIER) instanceof SortCommand);
+                + PREFIX_JOB_TYPE) instanceof SortCommand);
     }
 
     @Test

--- a/src/test/java/seedu/application/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/application/logic/parser/FindCommandParserTest.java
@@ -1,17 +1,18 @@
 package seedu.application.logic.parser;
 
 import static seedu.application.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.application.logic.Messages.MESSAGE_INVALID_SPECIFIER;
+//import static seedu.application.logic.parser.CliSyntax.PREFIX_COMPANY;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.application.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.application.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.application.model.job.FieldContainsKeywordsPredicateTest.INVALID_SPECIFIER;
-import static seedu.application.model.job.Role.ROLE_SPECIFIER;
+import static seedu.application.model.job.FieldContainsKeywordsPredicateTest.INVALID_PREFIX;
 
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.application.logic.commands.FindCommand;
+import seedu.application.model.job.CombinedPredicate;
 import seedu.application.model.job.FieldContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
@@ -24,21 +25,32 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parse_invalidSpecifier_throwsParseException() {
-        assertParseFailure(parser, INVALID_SPECIFIER,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_INVALID_SPECIFIER));
+    public void parse_invalidPrefix_throwsParseException() {
+        assertParseFailure(parser, INVALID_PREFIX + "Google",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_emptyKeywords_throwsParseException() {
+        assertParseFailure(parser, PREFIX_ROLE.toString(),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
+        FieldContainsKeywordsPredicate expectedFirstPredicate = new FieldContainsKeywordsPredicate(
+                PREFIX_ROLE, Arrays.asList("Software", "Grass"));
+        CombinedPredicate expectedCombinedPredicate = new CombinedPredicate(Arrays.asList(expectedFirstPredicate));
         FindCommand expectedFindCommand =
-                new FindCommand(
-                        new FieldContainsKeywordsPredicate(ROLE_SPECIFIER, Arrays.asList("Software", "Grass")));
-        assertParseSuccess(parser, ROLE_SPECIFIER + " Software Grass", expectedFindCommand);
+                new FindCommand(expectedCombinedPredicate);
+        assertParseSuccess(parser,
+                FindCommand.COMMAND_WORD + " "
+                        + PREFIX_ROLE + " Software Grass", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, ROLE_SPECIFIER + " \n Software \n \t Grass  \t", expectedFindCommand);
+        assertParseSuccess(parser, FindCommand.COMMAND_WORD + " "
+                + PREFIX_ROLE + " \n Software \n \t Grass  \t", expectedFindCommand);
     }
 
 }

--- a/src/test/java/seedu/application/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/application/logic/parser/SortCommandParserTest.java
@@ -8,32 +8,36 @@ import static seedu.application.model.job.Status.STATUS_SPECIFIER;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.application.logic.commands.ListCommand;
+import seedu.application.logic.commands.SortCommand;
 import seedu.application.model.job.FieldComparator;
 
-public class ListCommandParserTest {
+public class SortCommandParserTest {
 
-    private final ListCommandParser parser = new ListCommandParser();
+    private final SortCommandParser parser = new SortCommandParser();
 
     @Test
     public void parse_invalidArgs_throwParseException() {
-        // extra characters after "list" that are no specifiers
+        // extra characters after "sort" that are no specifiers
         assertParseFailure(parser, "by role",
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
 
         // more than one specifier
         assertParseFailure(parser, COMPANY_SPECIFIER + " " + STATUS_SPECIFIER,
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
 
         // invalid specifier
         assertParseFailure(parser, "-b",
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_INVALID_SPECIFIER));
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_INVALID_SPECIFIER));
+
+        // no arguments
+        assertParseFailure(parser, "",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_validArgs_returnsListCommand() {
         FieldComparator fieldComparator = new FieldComparator(COMPANY_SPECIFIER);
-        ListCommand expectedCommand = new ListCommand(fieldComparator);
+        SortCommand expectedCommand = new SortCommand(fieldComparator);
         assertParseSuccess(parser, COMPANY_SPECIFIER, expectedCommand);
     }
 }

--- a/src/test/java/seedu/application/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/application/logic/parser/SortCommandParserTest.java
@@ -1,10 +1,10 @@
 package seedu.application.logic.parser;
 
 import static seedu.application.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_COMPANY;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.application.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.application.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.application.model.job.Company.COMPANY_SPECIFIER;
-import static seedu.application.model.job.Status.STATUS_SPECIFIER;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,11 +22,11 @@ public class SortCommandParserTest {
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
 
         // more than one specifier
-        assertParseFailure(parser, COMPANY_SPECIFIER + " " + STATUS_SPECIFIER,
+        assertParseFailure(parser, PREFIX_COMPANY + " " + PREFIX_STATUS,
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
 
         // invalid specifier
-        assertParseFailure(parser, "-b",
+        assertParseFailure(parser, "b/",
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_INVALID_SPECIFIER));
 
         // no arguments
@@ -36,8 +36,8 @@ public class SortCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsListCommand() {
-        FieldComparator fieldComparator = new FieldComparator(COMPANY_SPECIFIER);
+        FieldComparator fieldComparator = new FieldComparator(PREFIX_COMPANY);
         SortCommand expectedCommand = new SortCommand(fieldComparator);
-        assertParseSuccess(parser, COMPANY_SPECIFIER, expectedCommand);
+        assertParseSuccess(parser, PREFIX_COMPANY.toString(), expectedCommand);
     }
 }

--- a/src/test/java/seedu/application/model/ModelManagerTest.java
+++ b/src/test/java/seedu/application/model/ModelManagerTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.application.model.Model.PREDICATE_SHOW_ALL_JOBS;
-import static seedu.application.model.job.Role.ROLE_SPECIFIER;
 import static seedu.application.testutil.Assert.assertThrows;
 import static seedu.application.testutil.TypicalJobs.CHEF;
 import static seedu.application.testutil.TypicalJobs.CLEANER;
@@ -17,6 +16,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.application.commons.core.GuiSettings;
+import seedu.application.logic.parser.CliSyntax;
 import seedu.application.model.job.FieldContainsKeywordsPredicate;
 import seedu.application.testutil.ApplicationBookBuilder;
 
@@ -121,7 +121,7 @@ public class ModelManagerTest {
         // different filteredList -> returns false
         String[] keywords = CHEF.getRole().description.split("\\s+");
         modelManager.updateFilteredJobList(
-                new FieldContainsKeywordsPredicate(ROLE_SPECIFIER, Arrays.asList(keywords)));
+                new FieldContainsKeywordsPredicate(CliSyntax.PREFIX_ROLE, Arrays.asList(keywords)));
         assertNotEquals(modelManager, new ModelManager(applicationBook, userPrefs));
 
         // resets modelManager to initial state for upcoming tests

--- a/src/test/java/seedu/application/model/job/FieldComparatorTest.java
+++ b/src/test/java/seedu/application/model/job/FieldComparatorTest.java
@@ -4,48 +4,34 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.application.model.job.Company.COMPANY_SPECIFIER;
-import static seedu.application.model.job.Deadline.DEADLINE_SPECIFIER;
+import static seedu.application.logic.parser.CliSyntax.*;
 import static seedu.application.model.job.Deadline.TO_ADD_DEADLINE;
-import static seedu.application.model.job.FieldComparator.EMPTY_COMPARATOR_SPECIFIER;
-import static seedu.application.model.job.Role.ROLE_SPECIFIER;
-import static seedu.application.model.job.Status.STATUS_SPECIFIER;
 import static seedu.application.testutil.TypicalJobs.CHEF;
 import static seedu.application.testutil.TypicalJobs.CLEANER;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.application.logic.parser.Prefix;
 import seedu.application.testutil.JobBuilder;
 
 public class FieldComparatorTest {
 
     @Test
     public void isValidSpecifier_validSpecifiers_returnTrue() {
-        assertTrue(FieldComparator.isValidSpecifier(EMPTY_COMPARATOR_SPECIFIER));
-        assertTrue(FieldComparator.isValidSpecifier(COMPANY_SPECIFIER));
-        assertTrue(FieldComparator.isValidSpecifier(ROLE_SPECIFIER));
-        assertTrue(FieldComparator.isValidSpecifier(DEADLINE_SPECIFIER));
-        assertTrue(FieldComparator.isValidSpecifier(STATUS_SPECIFIER));
+        assertTrue(FieldComparator.isValidPrefix(PREFIX_COMPANY.getPrefix()));
+        assertTrue(FieldComparator.isValidPrefix(PREFIX_ROLE.getPrefix()));
+        assertTrue(FieldComparator.isValidPrefix(PREFIX_STATUS.getPrefix()));
+        assertTrue(FieldComparator.isValidPrefix(PREFIX_INDUSTRY.getPrefix()));
+        assertTrue(FieldComparator.isValidPrefix(PREFIX_DEADLINE.getPrefix()));
+        assertTrue(FieldComparator.isValidPrefix(PREFIX_JOB_TYPE.getPrefix()));
     }
 
     @Test
     public void isValidSpecifier_invalidSpecifiers_returnFalse() {
-        assertFalse(FieldComparator.isValidSpecifier("x"));
-        assertFalse(FieldComparator.isValidSpecifier("description"));
-        assertFalse(FieldComparator.isValidSpecifier("-k"));
-        assertFalse(FieldComparator.isValidSpecifier(" "));
-    }
-
-    @Test
-    public void hasSpecifier_specifierPresent_returnsTrue() {
-        FieldComparator comparator = new FieldComparator(ROLE_SPECIFIER);
-        assertTrue(comparator.hasSpecifier());
-    }
-
-    @Test
-    public void hasSpecifier_noSpecifier_returnsFalse() {
-        FieldComparator comparator = new FieldComparator(EMPTY_COMPARATOR_SPECIFIER);
-        assertFalse(comparator.hasSpecifier());
+        assertFalse(FieldComparator.isValidPrefix("x"));
+        assertFalse(FieldComparator.isValidPrefix("description"));
+        assertFalse(FieldComparator.isValidPrefix("-k"));
+        assertFalse(FieldComparator.isValidPrefix(" "));
     }
 
     @Test
@@ -53,17 +39,14 @@ public class FieldComparatorTest {
         Job job1 = new JobBuilder(CLEANER).withDeadline(TO_ADD_DEADLINE).build();
         Job job2 = new JobBuilder(CHEF).withDeadline(TO_ADD_DEADLINE).build();
 
-        FieldComparator roleComparator = new FieldComparator(ROLE_SPECIFIER);
+        FieldComparator roleComparator = new FieldComparator(PREFIX_ROLE);
         assertTrue(roleComparator.compare(job1, job2) > 0); // job2 should be before job1
 
-        FieldComparator deadlineComparator = new FieldComparator(DEADLINE_SPECIFIER);
+        FieldComparator deadlineComparator = new FieldComparator(PREFIX_DEADLINE);
         assertEquals(0, deadlineComparator.compare(job1, job2)); // job1 and job2 has the same deadline
 
-        FieldComparator statusComparator = new FieldComparator(STATUS_SPECIFIER);
+        FieldComparator statusComparator = new FieldComparator(PREFIX_STATUS);
         assertTrue(statusComparator.compare(job1, job2) < 0); // job2 should be after job1
-
-        FieldComparator emptyComparator = new FieldComparator(EMPTY_COMPARATOR_SPECIFIER);
-        assertEquals(-1, emptyComparator.compare(job1, job2));
     }
 
     @Test
@@ -71,16 +54,16 @@ public class FieldComparatorTest {
         Job job1 = new JobBuilder(CHEF).build();
         Job job2 = new JobBuilder(CLEANER).build();
 
-        FieldComparator invalidComparator = new FieldComparator("x");
+        FieldComparator invalidComparator = new FieldComparator(new Prefix("x/"));
         assertEquals(-1, invalidComparator.compare(job1, job2));
     }
 
     @Test
     public void equals() {
-        FieldComparator fieldComparator = new FieldComparator(ROLE_SPECIFIER);
+        FieldComparator fieldComparator = new FieldComparator(PREFIX_ROLE);
 
         // same values -> returns true
-        assertEquals(fieldComparator, new FieldComparator(ROLE_SPECIFIER));
+        assertEquals(fieldComparator, new FieldComparator(PREFIX_ROLE));
 
         // same object -> returns true
         assertEquals(fieldComparator, fieldComparator);
@@ -92,6 +75,6 @@ public class FieldComparatorTest {
         assertNotEquals(fieldComparator, 5.0f);
 
         // different values -> returns false
-        assertNotEquals(fieldComparator, new FieldComparator(COMPANY_SPECIFIER));
+        assertNotEquals(fieldComparator, new FieldComparator(PREFIX_STATUS));
     }
 }

--- a/src/test/java/seedu/application/model/job/FieldContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/application/model/job/FieldContainsKeywordsPredicateTest.java
@@ -4,8 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.application.model.job.Company.COMPANY_SPECIFIER;
-import static seedu.application.model.job.Role.ROLE_SPECIFIER;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_COMPANY;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_DEADLINE;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_INDUSTRY;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_JOB_TYPE;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_STATUS;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -13,11 +17,13 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.application.model.job.JobType.JobTypes;
+import seedu.application.model.job.Status.JobStatus;
 import seedu.application.testutil.JobBuilder;
 
 public class FieldContainsKeywordsPredicateTest {
 
-    public static final String INVALID_SPECIFIER = "Scndkcjnkcsjn";
+    public static final String INVALID_PREFIX = "Scndkcjnkcsjn";
 
     @Test
     public void equals() {
@@ -25,16 +31,16 @@ public class FieldContainsKeywordsPredicateTest {
         List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
 
         FieldContainsKeywordsPredicate firstPredicate = new FieldContainsKeywordsPredicate(
-                ROLE_SPECIFIER, firstPredicateKeywordList);
+                PREFIX_ROLE, firstPredicateKeywordList);
         FieldContainsKeywordsPredicate secondPredicate = new FieldContainsKeywordsPredicate(
-                ROLE_SPECIFIER, secondPredicateKeywordList);
+                PREFIX_ROLE, secondPredicateKeywordList);
 
         // same object -> returns true
         assertEquals(firstPredicate, firstPredicate);
 
         // same values -> returns true
         FieldContainsKeywordsPredicate firstPredicateCopy =
-                new FieldContainsKeywordsPredicate(ROLE_SPECIFIER, firstPredicateKeywordList);
+                new FieldContainsKeywordsPredicate(PREFIX_ROLE, firstPredicateKeywordList);
         assertEquals(firstPredicate, firstPredicateCopy);
 
         // different types -> returns false
@@ -48,91 +54,199 @@ public class FieldContainsKeywordsPredicateTest {
     }
 
     @Test
-    public void isValidSpecifier() {
-        // valid specifier -> does not throw error
-        assertTrue(FieldContainsKeywordsPredicate.isValidSpecifier(COMPANY_SPECIFIER));
-        assertTrue(FieldContainsKeywordsPredicate.isValidSpecifier(ROLE_SPECIFIER));
+    public void test_companyContainsKeywords_returnsTrue() {
+        // One keyword
+        FieldContainsKeywordsPredicate predicate = new FieldContainsKeywordsPredicate(
+                PREFIX_COMPANY, Collections.singletonList("Google"));
+        assertTrue(predicate.test(new JobBuilder().withCompany("Google Singapore").build()));
 
-        // invalid specifier -> throws error
-        assertFalse(FieldContainsKeywordsPredicate.isValidSpecifier(INVALID_SPECIFIER));
+        // Multiple keywords
+        predicate = new FieldContainsKeywordsPredicate(PREFIX_COMPANY, Arrays.asList("Google", "Singapore"));
+        assertTrue(predicate.test(new JobBuilder().withCompany("Google Singapore").build()));
+
+        // Mixed-case keywords
+        predicate = new FieldContainsKeywordsPredicate(PREFIX_COMPANY, Arrays.asList("gOOgLe", "SinGApOre"));
+        assertTrue(predicate.test(new JobBuilder().withCompany("Google Singapore").build()));
+    }
+
+    @Test
+    public void test_companyDoesNotContainKeywords_returnsFalse() {
+        // Only one matching keyword
+        FieldContainsKeywordsPredicate predicate = new FieldContainsKeywordsPredicate(
+                PREFIX_COMPANY, Arrays.asList("Google", "Malaysia"));
+        assertFalse(predicate.test(new JobBuilder().withCompany("Google Singapore").build()));
+
+        // Non-matching keyword
+        predicate = new FieldContainsKeywordsPredicate(PREFIX_COMPANY, Arrays.asList("Apple"));
+        assertFalse(predicate.test(new JobBuilder().withCompany("Google Singapore").build()));
+
+        // Keywords match role, but does not match company
+        predicate = new FieldContainsKeywordsPredicate(PREFIX_COMPANY, Arrays.asList("Software"));
+        assertFalse(predicate.test(new JobBuilder().withRole("Software Engineer").withCompany("Google").build()));
     }
 
     @Test
     public void test_roleContainsKeywords_returnsTrue() {
         // One keyword
         FieldContainsKeywordsPredicate predicate = new FieldContainsKeywordsPredicate(
-                ROLE_SPECIFIER, Collections.singletonList("Software"));
+                PREFIX_ROLE, Collections.singletonList("Software"));
         assertTrue(predicate.test(new JobBuilder().withRole("Software Engineer").build()));
 
         // Multiple keywords
-        predicate = new FieldContainsKeywordsPredicate(ROLE_SPECIFIER, Arrays.asList("Software", "Engineer"));
-        assertTrue(predicate.test(new JobBuilder().withRole("Software Engineer").build()));
-
-        // Only one matching keyword
-        predicate = new FieldContainsKeywordsPredicate(ROLE_SPECIFIER, Arrays.asList("Mechanical", "Engineer"));
+        predicate = new FieldContainsKeywordsPredicate(PREFIX_ROLE, Arrays.asList("Software", "Engineer"));
         assertTrue(predicate.test(new JobBuilder().withRole("Software Engineer").build()));
 
         // Mixed-case keywords
-        predicate = new FieldContainsKeywordsPredicate(ROLE_SPECIFIER, Arrays.asList("sOFtwaRe", "EnGIneer"));
+        predicate = new FieldContainsKeywordsPredicate(PREFIX_ROLE, Arrays.asList("sOFtwaRe", "EnGIneer"));
         assertTrue(predicate.test(new JobBuilder().withRole("Software Engineer").build()));
     }
 
     @Test
     public void test_roleDoesNotContainKeywords_returnsFalse() {
-        // Zero keywords
-        FieldContainsKeywordsPredicate predicate = new FieldContainsKeywordsPredicate(
-                ROLE_SPECIFIER, Collections.emptyList());
-        assertFalse(predicate.test(new JobBuilder().withRole("Engineer").build()));
+        // Only one matching keyword
+        FieldContainsKeywordsPredicate predicate =
+                new FieldContainsKeywordsPredicate(PREFIX_ROLE, Arrays.asList("Mechanical", "Engineer"));
+        assertFalse(predicate.test(new JobBuilder().withRole("Software Engineer").build()));
 
         // Non-matching keyword
-        predicate = new FieldContainsKeywordsPredicate(ROLE_SPECIFIER, Arrays.asList("Chef"));
+        predicate = new FieldContainsKeywordsPredicate(PREFIX_ROLE, Arrays.asList("Chef"));
         assertFalse(predicate.test(new JobBuilder().withRole("Software Engineer").build()));
 
         // Keywords match company, but does not match role
-        predicate = new FieldContainsKeywordsPredicate(ROLE_SPECIFIER, Arrays.asList("Google"));
+        predicate = new FieldContainsKeywordsPredicate(PREFIX_ROLE, Arrays.asList("Google"));
         assertFalse(predicate.test(new JobBuilder().withRole("Software Engineer").withCompany("Google").build()));
     }
 
+
+
     @Test
-    public void test_companyContainsKeywords_returnsTrue() {
+    public void test_statusContainsKeywords_returnsTrue() {
         // One keyword
         FieldContainsKeywordsPredicate predicate = new FieldContainsKeywordsPredicate(
-                COMPANY_SPECIFIER, Collections.singletonList("Google"));
-        assertTrue(predicate.test(new JobBuilder().withCompany("Google Singapore").build()));
-
-        // Multiple keywords
-        predicate = new FieldContainsKeywordsPredicate(COMPANY_SPECIFIER, Arrays.asList("Google", "Singapore"));
-        assertTrue(predicate.test(new JobBuilder().withCompany("Google Singapore").build()));
-
-        // Only one matching keyword
-        predicate = new FieldContainsKeywordsPredicate(COMPANY_SPECIFIER, Arrays.asList("Google", "Malaysia"));
-        assertTrue(predicate.test(new JobBuilder().withCompany("Google Malaysia").build()));
+                PREFIX_STATUS, Collections.singletonList(JobStatus.PENDING.toString()));
+        assertTrue(predicate.test(new JobBuilder().withStatus(JobStatus.PENDING.toString()).build()));
 
         // Mixed-case keywords
-        predicate = new FieldContainsKeywordsPredicate(COMPANY_SPECIFIER, Arrays.asList("gOOgLe", "SinGApOre"));
+        predicate = new FieldContainsKeywordsPredicate(PREFIX_STATUS, Arrays.asList("pEnDing"));
+        assertTrue(predicate.test(new JobBuilder().withStatus(JobStatus.PENDING.toString()).build()));
+    }
+
+    @Test
+    public void test_statusDoesNotContainKeywords_returnsFalse() {
+        // Multiple keywords
+        FieldContainsKeywordsPredicate predicate = new FieldContainsKeywordsPredicate(
+                PREFIX_STATUS, Arrays.asList(JobStatus.PENDING.toString(), JobStatus.APPROVED.toString()));
+        assertFalse(predicate.test(new JobBuilder().withStatus(JobStatus.PENDING.toString()).build()));
+
+        // Non-matching keyword
+        predicate = new FieldContainsKeywordsPredicate(PREFIX_STATUS, Arrays.asList("Apple"));
+        assertFalse(predicate.test(new JobBuilder().withStatus(JobStatus.PENDING.toString()).build()));
+
+        // Keywords match company, but does not match status
+        predicate = new FieldContainsKeywordsPredicate(PREFIX_STATUS, Arrays.asList(JobStatus.PENDING.toString()));
+        assertFalse(predicate.test(new JobBuilder()
+                .withRole(JobStatus.APPROVED.toString())
+                .withCompany(JobStatus.PENDING.toString()).build()));
+    }
+
+    @Test
+    public void test_industryContainsKeywords_returnsTrue() {
+        // One keyword
+        FieldContainsKeywordsPredicate predicate = new FieldContainsKeywordsPredicate(
+                PREFIX_INDUSTRY, Collections.singletonList("Tech"));
+        assertTrue(predicate.test(new JobBuilder().withIndustry("Tech").build()));
+
+        // Multiple keywords
+        predicate = new FieldContainsKeywordsPredicate(PREFIX_INDUSTRY, Arrays.asList("Food", "Science"));
+        assertTrue(predicate.test(new JobBuilder().withIndustry("Food Science").build()));
+
+        // Mixed-case keywords
+        predicate = new FieldContainsKeywordsPredicate(PREFIX_INDUSTRY, Arrays.asList("fOOd", "sCIEnce"));
+        assertTrue(predicate.test(new JobBuilder().withIndustry("Food Science").build()));
+    }
+
+    @Test
+    public void test_industryDoesNotContainKeywords_returnsFalse() {
+        // Only one matching keyword
+        FieldContainsKeywordsPredicate predicate = new FieldContainsKeywordsPredicate(
+                PREFIX_INDUSTRY, Arrays.asList("Food", "Science"));
+        assertFalse(predicate.test(new JobBuilder().withIndustry("Computer Science").build()));
+
+        // Non-matching keyword
+        predicate = new FieldContainsKeywordsPredicate(PREFIX_INDUSTRY, Arrays.asList("Apple"));
+        assertFalse(predicate.test(new JobBuilder().withIndustry("Food Science").build()));
+
+        // Keywords match role, but does not match industry
+        predicate = new FieldContainsKeywordsPredicate(PREFIX_INDUSTRY, Arrays.asList("Food"));
+        assertFalse(predicate.test(new JobBuilder().withRole("Food Science").withIndustry("Computer Science").build()));
+    }
+
+    @Test
+    public void test_deadlineContainsKeywords_returnsTrue() {
+        // One keyword
+        FieldContainsKeywordsPredicate predicate = new FieldContainsKeywordsPredicate(
+                PREFIX_DEADLINE, Collections.singletonList("Dec"));
+        assertTrue(predicate.test(new JobBuilder().withDeadline("Dec 01 2030 1200").build()));
+
+        // Multiple keywords
+        predicate = new FieldContainsKeywordsPredicate(PREFIX_DEADLINE, Arrays.asList("Dec", "01"));
+        assertTrue(predicate.test(new JobBuilder().withDeadline("Dec 01 2030 1200").build()));
+
+        // Mixed-case keywords
+        predicate = new FieldContainsKeywordsPredicate(PREFIX_DEADLINE, Arrays.asList("deC", "01"));
+        assertTrue(predicate.test(new JobBuilder().withDeadline("Dec 01 2030 1200").build()));
+    }
+
+    @Test
+    public void test_deadlineDoesNotContainKeywords_returnsFalse() {
+        // Only one matching keyword
+        FieldContainsKeywordsPredicate predicate = new FieldContainsKeywordsPredicate(
+                PREFIX_COMPANY, Arrays.asList("Sep", "01"));
+        assertFalse(predicate.test(new JobBuilder().withDeadline("Dec 01 2030 1200").build()));
+
+        // Non-matching keyword
+        predicate = new FieldContainsKeywordsPredicate(PREFIX_DEADLINE, Arrays.asList("Sep"));
+        assertFalse(predicate.test(new JobBuilder().withDeadline("Dec 01 2030 1200").build()));
+
+        // Keywords match company, but does not match deadline
+        predicate = new FieldContainsKeywordsPredicate(PREFIX_DEADLINE, Arrays.asList("Dec"));
+        assertFalse(predicate.test(new JobBuilder().withDeadline("Sep 01 2030 1200").withCompany("Dec").build()));
+    }
+
+    @Test
+    public void test_jobTypeContainsKeywords_returnsTrue() {
+        // One keyword
+        FieldContainsKeywordsPredicate predicate = new FieldContainsKeywordsPredicate(
+                PREFIX_COMPANY, Collections.singletonList("Google"));
+        assertTrue(predicate.test(new JobBuilder().withCompany("Google Singapore").build()));
+
+        // Mixed-case keywords
+        predicate = new FieldContainsKeywordsPredicate(PREFIX_COMPANY, Arrays.asList("gOOgLe", "SinGApOre"));
         assertTrue(predicate.test(new JobBuilder().withCompany("Google Singapore").build()));
     }
 
     @Test
-    public void test_companyDoesNotContainKeywords_returnsFalse() {
-        // Zero keywords
+    public void test_jobTypeDoesNotContainKeywords_returnsFalse() {
+        // Multiple keywords
         FieldContainsKeywordsPredicate predicate = new FieldContainsKeywordsPredicate(
-                COMPANY_SPECIFIER, Collections.emptyList());
-        assertFalse(predicate.test(new JobBuilder().withCompany("Google").build()));
+                PREFIX_JOB_TYPE, Arrays.asList(JobTypes.CONTRACT.toString(), JobTypes.FREELANCE.toString()));
+        assertFalse(predicate.test(new JobBuilder().withJobType(JobTypes.CONTRACT.toString()).build()));
 
         // Non-matching keyword
-        predicate = new FieldContainsKeywordsPredicate(COMPANY_SPECIFIER, Arrays.asList("Apple"));
-        assertFalse(predicate.test(new JobBuilder().withCompany("Google Singapore").build()));
+        predicate = new FieldContainsKeywordsPredicate(PREFIX_JOB_TYPE, Arrays.asList(JobTypes.FREELANCE.toString()));
+        assertFalse(predicate.test(new JobBuilder().withJobType(JobTypes.CONTRACT.toString()).build()));
 
         // Keywords match role, but does not match company
-        predicate = new FieldContainsKeywordsPredicate(COMPANY_SPECIFIER, Arrays.asList("Software"));
-        assertFalse(predicate.test(new JobBuilder().withRole("Software Engineer").withCompany("Google").build()));
+        predicate = new FieldContainsKeywordsPredicate(PREFIX_JOB_TYPE, Arrays.asList(JobTypes.FREELANCE.toString()));
+        assertFalse(predicate.test(new JobBuilder()
+                .withRole(JobTypes.FREELANCE.toString())
+                .withCompany(JobTypes.CONTRACT.toString()).build()));
     }
 
     @Test
     public void toStringMethod() {
         List<String> keywords = List.of("keyword1", "keyword2");
-        FieldContainsKeywordsPredicate predicate = new FieldContainsKeywordsPredicate(ROLE_SPECIFIER, keywords);
+        FieldContainsKeywordsPredicate predicate = new FieldContainsKeywordsPredicate(PREFIX_COMPANY, keywords);
         String expected = FieldContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=" + keywords + "}";
         assertEquals(expected, predicate.toString());
     }

--- a/src/test/java/seedu/application/testutil/JobBuilder.java
+++ b/src/test/java/seedu/application/testutil/JobBuilder.java
@@ -62,7 +62,7 @@ public class JobBuilder {
     }
 
     /**
-     * Sets the {@code Status} of the {@code Job} that we are building.
+     * Sets the {@code Deadline} of the {@code Job} that we are building.
      */
     public JobBuilder withDeadline(String deadline) {
         this.deadline = new Deadline(deadline);
@@ -70,7 +70,7 @@ public class JobBuilder {
     }
 
     /**
-     * Sets the {@code Company} of the {@code Job} that we are building.
+     * Sets the {@code Status} of the {@code Job} that we are building.
      */
     public JobBuilder withStatus(String status) {
         this.status = new Status(status);


### PR DESCRIPTION
* `list` now removes and filter but preserves sort order.
* `find` now supports searching by multiple fields. All keywords provided must match.
* `find` and `sort` commands can be done on all fields.

Tests are not implemented yet.