### PR TITLE
Add Interview class and fields

### DIFF
--- a/src/main/java/seedu/application/model/job/interview/Interview.java
+++ b/src/main/java/seedu/application/model/job/interview/Interview.java
@@ -1,0 +1,75 @@
+package seedu.application.model.job.interview;
+
+import java.util.Objects;
+
+import seedu.application.commons.util.CollectionUtil;
+import seedu.application.commons.util.ToStringBuilder;
+
+/**
+ * Represents an Interview in the application book.
+ * Guarantees: details are present and not null, field values are validated, immutable.
+ */
+public class Interview {
+
+    public final InterviewType interviewType;
+    public final InterviewDateTime interviewDateTime;
+    public final InterviewAddress interviewAddress;
+
+    /**
+     * Constructs a {@code Interview}.
+     *
+     * @param interviewType A valid interview type.
+     * @param interviewDateTime A valid interview date and time.
+     * @param interviewAddress A valid interview address.
+     */
+    public Interview(InterviewType interviewType, InterviewDateTime interviewDateTime,
+                     InterviewAddress interviewAddress) {
+        CollectionUtil.requireAllNonNull(interviewType, interviewDateTime, interviewAddress);
+        this.interviewType = interviewType;
+        this.interviewDateTime = interviewDateTime;
+        this.interviewAddress = interviewAddress;
+    }
+
+    public InterviewType getInterviewType() {
+        return interviewType;
+    }
+
+    public InterviewDateTime getInterviewDateTime() {
+        return interviewDateTime;
+    }
+
+    public InterviewAddress getInterviewAddress() {
+        return interviewAddress;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof Interview)) {
+            return false;
+        }
+
+        Interview interview = (Interview) other;
+        return interview.getInterviewType().equals(getInterviewType())
+                && interview.getInterviewDateTime().equals(getInterviewDateTime())
+                && interview.getInterviewAddress().equals(getInterviewAddress());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(interviewType, interviewDateTime, interviewAddress);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+            .add("interviewType", interviewType)
+            .add("interviewDateTime", interviewDateTime)
+            .add("interviewAddress", interviewAddress)
+            .toString();
+    }
+}
+

--- a/src/main/java/seedu/application/model/job/interview/InterviewAddress.java
+++ b/src/main/java/seedu/application/model/job/interview/InterviewAddress.java
@@ -1,0 +1,71 @@
+package seedu.application.model.job.interview;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.application.commons.util.AppUtil;
+
+/**
+ * Represents an Interview's address in the application book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidInterviewAddress(String)}
+ */
+public class InterviewAddress {
+    public static final String MESSAGE_CONSTRAINTS =
+            "Address descriptions should adhere to the following constraints:\n"
+                    + "1. The first character must not be a whitespace \n";
+
+    public static final String TO_ADD_INTERVIEW_ADDRESS = "TO_ADD_INTERVIEW_ADDRESS";
+    public static final InterviewAddress DEFAULT_INTERVIEW_ADDRESS =
+            new InterviewAddress(TO_ADD_INTERVIEW_ADDRESS);
+
+    /*
+     * The first character of interview address must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[^\\s].*";
+
+    public final String interviewAddress;
+
+    /**
+     * Constructs a {@code InterviewAddress}.
+     *
+     * @param interviewAddress A valid interview address.
+     */
+    public InterviewAddress(String interviewAddress) {
+        requireNonNull(interviewAddress);
+        AppUtil.checkArgument(isValidInterviewAddress(interviewAddress), MESSAGE_CONSTRAINTS);
+        this.interviewAddress = interviewAddress;
+    }
+
+    /**
+     * Returns true if a given string is a valid interview address.
+     */
+    public static boolean isValidInterviewAddress(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return interviewAddress;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof InterviewAddress)) {
+            return false;
+        }
+
+        InterviewAddress otherInterviewAddress = (InterviewAddress) other;
+        return interviewAddress.equals(otherInterviewAddress.interviewAddress);
+    }
+
+    @Override
+    public int hashCode() {
+        return interviewAddress.hashCode();
+    }
+}
+

--- a/src/main/java/seedu/application/model/job/interview/InterviewDateTime.java
+++ b/src/main/java/seedu/application/model/job/interview/InterviewDateTime.java
@@ -1,0 +1,126 @@
+package seedu.application.model.job.interview;
+
+import static java.util.Objects.requireNonNull;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import seedu.application.commons.util.AppUtil;
+
+/**
+ * Represents an Interview's date and time in the application book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidInterviewDateTime(String)}
+ */
+public class InterviewDateTime {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Date and Time should be in valid DateTime format: "
+                    + "MMM dd yyyy HHmm\n"
+                    + "Eg. Dec 31 2030 1200";
+
+    public static final String TO_ADD_INTERVIEW_DATE_TIME = "TO_ADD_INTERVIEW_DATE_TIME";
+    public static final InterviewDateTime EMPTY_INTERVIEW_DATE_TIME =
+            new InterviewDateTime(TO_ADD_INTERVIEW_DATE_TIME);
+    public static final String DEFAULT_DATETIME_FORMAT = "MMM dd yyyy HHmm";
+    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(DEFAULT_DATETIME_FORMAT);
+
+    public final String interviewDateTime;
+
+    /**
+     * Constructs a {@code InterviewDateTime}.
+     *
+     * @param dateTime A valid dateTime.
+     */
+    public InterviewDateTime(String dateTime) {
+        requireNonNull(dateTime);
+        AppUtil.checkArgument(isValidInterviewDateTime(dateTime), MESSAGE_CONSTRAINTS);
+
+        if (isEmptyInterviewDateTime(dateTime)) {
+            this.interviewDateTime = TO_ADD_INTERVIEW_DATE_TIME;
+        } else {
+            this.interviewDateTime = dateTime;
+        }
+    }
+
+    /**
+     * Returns true if a given string is a valid interview date time.
+     */
+    public static boolean isValidInterviewDateTime(String test) {
+        if (isEmptyInterviewDateTime(test)) {
+            return true;
+        }
+        try {
+            LocalDateTime dateTime = LocalDateTime.parse(test, DATE_TIME_FORMATTER);
+            LocalDateTime current = LocalDateTime.now();
+            return dateTime.format(DATE_TIME_FORMATTER).equals(test)
+                    && dateTime.isAfter(current);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns true if a given string is an empty interview date time.
+     */
+    private static boolean isEmptyInterviewDateTime(String test) {
+        return test.equals(TO_ADD_INTERVIEW_DATE_TIME);
+    }
+
+    /**
+     * Checks if the date and time represented by this {@code InterviewDateTime} is earlier
+     * than the other InterviewDateTime. Empty interviewDateTimes are considered to be earlier.
+     *
+     * @param other The other {@code InterviewDateTime} to be compared to.
+     * @return -1 if this InterviewDateTime is earlier, 0 if they are equal, and 1 if it is later.
+     */
+    public int compareTo(InterviewDateTime other) {
+        if (this.interviewDateTime.equals(TO_ADD_INTERVIEW_DATE_TIME)) {
+            return other.interviewDateTime.equals(TO_ADD_INTERVIEW_DATE_TIME) ? 0 : -1;
+        }
+
+        if (other.interviewDateTime.equals(TO_ADD_INTERVIEW_DATE_TIME)) {
+            return 1;
+        }
+
+        LocalDateTime thisDateTime = LocalDateTime.parse(this.interviewDateTime, DATE_TIME_FORMATTER);
+        LocalDateTime otherDateTime = LocalDateTime.parse(other.interviewDateTime, DATE_TIME_FORMATTER);
+
+        if (thisDateTime.equals(otherDateTime)) {
+            return 0;
+        } else if (thisDateTime.isAfter(otherDateTime)) {
+            return 1;
+        } else {
+            return -1;
+        }
+    }
+
+    @Override
+    public String toString() {
+        if (isEmptyInterviewDateTime(interviewDateTime)) {
+            return TO_ADD_INTERVIEW_DATE_TIME;
+        } else {
+            LocalDateTime parsedInterviewDateTime = LocalDateTime.parse(interviewDateTime, DATE_TIME_FORMATTER);
+            return parsedInterviewDateTime.format(DATE_TIME_FORMATTER);
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof InterviewDateTime)) {
+            return false;
+        }
+
+        InterviewDateTime otherInterviewDateTime = (InterviewDateTime) other;
+        return interviewDateTime.equals(otherInterviewDateTime.interviewDateTime);
+    }
+
+    @Override
+    public int hashCode() {
+        return interviewDateTime.hashCode();
+    }
+}

--- a/src/main/java/seedu/application/model/job/interview/InterviewType.java
+++ b/src/main/java/seedu/application/model/job/interview/InterviewType.java
@@ -1,0 +1,92 @@
+package seedu.application.model.job.interview;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.application.commons.util.AppUtil;
+
+/**
+ * Represents an Interview's type in the application book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidInterviewType(String)}
+ */
+public class InterviewType {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Type is not case sensitive and should only be in the form: \n"
+                    + "BEHAVIOURAL, TECHNICAL, CASE, GROUP, PHONE, VIDEO, ONLINE, ONSITE, OTHER";
+
+    public static final String TO_ADD_INTERVIEW_TYPE = "TO_ADD_INTERVIEW_TYPE";
+    public static final InterviewType EMPTY_INTERVIEW_TYPE = new InterviewType(TO_ADD_INTERVIEW_TYPE);
+    public final String interviewType;
+    /**
+     * Enum for interview types
+     */
+    public enum InterviewTypes {
+        BEHAVIOURAL, TECHNICAL, CASE, GROUP, PHONE, VIDEO, ONLINE, ONSITE, OTHER
+    }
+
+    /**
+     * Constructs a {@code InterviewType}.
+     *
+     * @param interviewType A valid interviewType.
+     */
+    public InterviewType(String interviewType) {
+        requireNonNull(interviewType);
+        AppUtil.checkArgument(isValidInterviewType(interviewType), MESSAGE_CONSTRAINTS);
+        if (isEmptyInterviewType(interviewType)) {
+            this.interviewType = TO_ADD_INTERVIEW_TYPE;
+        } else {
+            this.interviewType = interviewType;
+        }
+    }
+
+    /**
+     * Returns true if a given string is a valid interviewType.
+     */
+    public static boolean isValidInterviewType(String test) {
+        if (isEmptyInterviewType(test)) {
+            return true;
+        }
+        for (InterviewType.InterviewTypes t : InterviewType.InterviewTypes.values()) {
+            if (test.equalsIgnoreCase(t.toString())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if a given string is an empty interviewType.
+     */
+    private static boolean isEmptyInterviewType(String test) {
+        return test.equals(TO_ADD_INTERVIEW_TYPE);
+    }
+
+    @Override
+    public String toString() {
+        if (isEmptyInterviewType(interviewType)) {
+            return TO_ADD_INTERVIEW_TYPE;
+        } else {
+            return interviewType;
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof InterviewType)) {
+            return false;
+        }
+
+        InterviewType otherInterviewType = (InterviewType) other;
+        return interviewType.equals(otherInterviewType.interviewType);
+    }
+
+    @Override
+    public int hashCode() {
+        return interviewType.hashCode();
+    }
+}

--- a/src/main/java/seedu/application/ui/InterviewCard.java
+++ b/src/main/java/seedu/application/ui/InterviewCard.java
@@ -1,0 +1,38 @@
+package seedu.application.ui;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import seedu.application.model.job.interview.Interview;
+
+/**
+ * A UI component that shows information regarding an {@code Interview}.
+ */
+public class InterviewCard extends UiPart<Region> {
+
+    public static final String FXML = "InterviewCard.fxml";
+
+    public final Interview interview;
+
+    @FXML
+    private HBox cardPane;
+
+    @FXML
+    private Label title;
+
+    @FXML
+    private Label date;
+
+    @FXML
+    private Label address;
+
+    /**
+     * Creates a {@code InterviewCard} with the given {@code Interview} and index to display.
+     */
+    public InterviewCard(Interview interview, int index) {
+        super(FXML);
+        this.interview = interview;
+        String title = "Interview ";
+    }
+}


### PR DESCRIPTION
Add Interview class for the interview panel.
Added relevant fields such as:
- Interview type (BEHAVIOURAL, TECHNICAL, CASE, GROUP, PHONE, VIDEO, ONLINE, ONSITE, OTHER)
- Interview date time
- Interview address
Implementation of these fields are similar to their job counterparts (e.g. `jobType`, `Deadline`, and `Industry`)