### PR TITLE
Update FindCommand

### DIFF
--- a/src/main/java/seedu/application/model/job/CombinedPredicate.java
+++ b/src/main/java/seedu/application/model/job/CombinedPredicate.java
@@ -8,9 +8,9 @@ import java.util.function.Predicate;
  * Represents a predicate that is the logical AND of all {@code FieldContainsKeyWordsPredicate} objects supplied to it.
  */
 public class CombinedPredicate implements Predicate<Job> {
-    private List<FieldContainsKeywordsPredicate> predicateList;
+    private List<Predicate<Job>> predicateList;
 
-    public CombinedPredicate(List<FieldContainsKeywordsPredicate> predicateList) {
+    public CombinedPredicate(List<Predicate<Job>> predicateList) {
         this.predicateList = new ArrayList<>(predicateList);
     }
 
@@ -40,7 +40,7 @@ public class CombinedPredicate implements Predicate<Job> {
             return false;
         }
 
-        for (FieldContainsKeywordsPredicate p : predicateList) {
+        for (Predicate<Job> p : predicateList) {
             if (!otherCombinedPredicate.predicateList.contains(p)) {
                 return false;
             }

--- a/src/main/java/seedu/application/model/job/FieldContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/application/model/job/FieldContainsKeywordsPredicate.java
@@ -1,11 +1,18 @@
 package seedu.application.model.job;
 
+import static seedu.application.logic.parser.CliSyntax.PREFIX_COMPANY;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_DEADLINE;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_INDUSTRY;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_JOB_TYPE;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.application.logic.parser.CliSyntax.PREFIX_STATUS;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 
 import seedu.application.commons.util.StringUtil;
 import seedu.application.commons.util.ToStringBuilder;
-import seedu.application.logic.parser.CliSyntax;
 import seedu.application.logic.parser.Prefix;
 
 /**
@@ -25,45 +32,53 @@ public class FieldContainsKeywordsPredicate implements Predicate<Job> {
         this.keywords = keywords;
     }
 
+    /**
+     * Generates a {@code Predicate<Job>} which is used to filter the list as specified the preamble.
+     * @param keywords The list of keywords in the preamble.
+     * @return the {@code Predicate<Job>} to be passed into the constructor for {@code CombinedPredicate}.
+     */
+    public static Predicate<Job> getPreamblePredicate(List<String> keywords) {
+        Predicate<Job> preamblePredicate = x -> true;
+        for (String keyword : keywords) {
+            Predicate<Job> allFieldsPredicate = x -> false;
+            allFieldsPredicate = allFieldsPredicate
+                    .or(new FieldContainsKeywordsPredicate(PREFIX_COMPANY, Collections.singletonList(keyword)))
+                    .or(new FieldContainsKeywordsPredicate(PREFIX_ROLE, Collections.singletonList(keyword)))
+                    .or(new FieldContainsKeywordsPredicate(PREFIX_STATUS, Collections.singletonList(keyword)))
+                    .or(new FieldContainsKeywordsPredicate(PREFIX_INDUSTRY, Collections.singletonList(keyword)))
+                    .or(new FieldContainsKeywordsPredicate(PREFIX_DEADLINE, Collections.singletonList(keyword)))
+                    .or(new FieldContainsKeywordsPredicate(PREFIX_JOB_TYPE, Collections.singletonList(keyword)));
+            preamblePredicate = preamblePredicate.and(allFieldsPredicate);
+        }
+        return preamblePredicate;
+    }
+
     private String getField(Job job) {
-        if (prefix.equals(CliSyntax.PREFIX_COMPANY)) {
+        if (prefix.equals(PREFIX_COMPANY)) {
             return job.getCompany().name;
         }
 
-        if (prefix.equals(CliSyntax.PREFIX_ROLE)) {
+        if (prefix.equals(PREFIX_ROLE)) {
             return job.getRole().description;
         }
 
-        if (prefix.equals(CliSyntax.PREFIX_STATUS)) {
+        if (prefix.equals(PREFIX_STATUS)) {
             return job.getStatus().status;
         }
 
-        if (prefix.equals(CliSyntax.PREFIX_INDUSTRY)) {
+        if (prefix.equals(PREFIX_INDUSTRY)) {
             return job.getIndustry().industry;
         }
 
-        if (prefix.equals(CliSyntax.PREFIX_DEADLINE)) {
+        if (prefix.equals(PREFIX_DEADLINE)) {
             return job.getDeadline().deadline;
         }
 
-        if (prefix.equals(CliSyntax.PREFIX_JOB_TYPE)) {
+        if (prefix.equals(PREFIX_JOB_TYPE)) {
             return job.getJobType().jobType;
         }
 
         return null;
-    }
-
-    /**
-     * Checks if a {@code Prefix} is a valid prefix in the context of the Find command.
-     * @param prefix The prefix specified by the user.
-     */
-    public static boolean isValidPrefix(Prefix prefix) {
-        return prefix.equals(CliSyntax.PREFIX_COMPANY)
-                || prefix.equals(CliSyntax.PREFIX_ROLE)
-                || prefix.equals(CliSyntax.PREFIX_STATUS)
-                || prefix.equals(CliSyntax.PREFIX_INDUSTRY)
-                || prefix.equals(CliSyntax.PREFIX_DEADLINE)
-                || prefix.equals(CliSyntax.PREFIX_JOB_TYPE);
     }
 
     @Override

--- a/src/test/java/seedu/application/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/application/logic/parser/FindCommandParserTest.java
@@ -5,7 +5,6 @@ import static seedu.application.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static seedu.application.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.application.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.application.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.application.model.job.FieldContainsKeywordsPredicateTest.INVALID_PREFIX;
 
 import java.util.Arrays;
 
@@ -21,19 +20,14 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-    }
-
-    @Test
-    public void parse_invalidPrefix_throwsParseException() {
-        assertParseFailure(parser, INVALID_PREFIX + "Google",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_EMPTY_KEYWORDS));
     }
 
     @Test
     public void parse_emptyKeywords_throwsParseException() {
-        assertParseFailure(parser, PREFIX_ROLE.toString(),
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " " + PREFIX_ROLE.toString(),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_EMPTY_KEYWORDS));
     }
 
     @Test

--- a/src/test/java/seedu/application/model/job/FieldContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/application/model/job/FieldContainsKeywordsPredicateTest.java
@@ -23,8 +23,6 @@ import seedu.application.testutil.JobBuilder;
 
 public class FieldContainsKeywordsPredicateTest {
 
-    public static final String INVALID_PREFIX = "Scndkcjnkcsjn";
-
     @Test
     public void equals() {
         List<String> firstPredicateKeywordList = Collections.singletonList("first");
@@ -51,6 +49,20 @@ public class FieldContainsKeywordsPredicateTest {
 
         // different predicate -> returns false
         assertNotEquals(firstPredicate, secondPredicate);
+    }
+
+    @Test
+    public void getPreamblePredicate() {
+        List<String> oneKeyword = Arrays.asList("one");
+        List<String> oneAndTwoKeywords = Arrays.asList("one", "two");
+
+        // One keyword
+        assertTrue(FieldContainsKeywordsPredicate.getPreamblePredicate(oneKeyword).test(
+                new JobBuilder().withCompany("one").build()));
+
+        // Multiple keywords
+        assertTrue(FieldContainsKeywordsPredicate.getPreamblePredicate(oneAndTwoKeywords).test(
+                new JobBuilder().withCompany("two").withRole("one").build()));
     }
 
     @Test


### PR DESCRIPTION
* `find` command now supports searching without a prefix.
* If multiple keywords are provided in the preamble, all of them must match at least one of the fields. They do not have to match the same field.
* Updated tests to confirm the above functionality.