### PR TITLE
Test classes related to delete interview command

### DIFF
--- a/src/main/java/seedu/application/logic/commands/InterviewAddCommand.java
+++ b/src/main/java/seedu/application/logic/commands/InterviewAddCommand.java
@@ -19,7 +19,7 @@ public class InterviewAddCommand extends InterviewCommand {
     public static final String COMMAND_WORD = "add";
 
     public static final String MESSAGE_USAGE = InterviewCommand.COMMAND_WORD
-        + COMMAND_WORD + ": Adds an interview to the job. "
+        + " " + COMMAND_WORD + ": Adds an interview to the job. "
         + "Parameters: INDEX (must be a positive integer)\n"
         + PREFIX_INTERVIEW_TYPE + "INTERVIEW TYPE "
         + PREFIX_INTERVIEW_DATETIME + "INTERVIEW DATE AND TIME "

--- a/src/main/java/seedu/application/logic/commands/InterviewDeleteCommand.java
+++ b/src/main/java/seedu/application/logic/commands/InterviewDeleteCommand.java
@@ -12,6 +12,7 @@ import seedu.application.logic.Messages;
 import seedu.application.logic.commands.exceptions.CommandException;
 import seedu.application.model.Model;
 import seedu.application.model.job.Job;
+import seedu.application.model.job.interview.Interview;
 
 /**
  * Deletes an interview of a job in the application book.
@@ -63,8 +64,8 @@ public class InterviewDeleteCommand extends InterviewCommand {
         if (interviewIndex.getZeroBased() >= jobToDeleteInterview.interviewLength()) {
             throw new CommandException(Messages.MESSAGE_INVALID_INTERVIEW);
         }
-
-        jobToDeleteInterview.deleteInterview(interviewIndex);
+        Interview interviewToDelete = jobToDeleteInterview.getInterview(interviewIndex);
+        model.deleteInterview(jobToDeleteInterview, interviewToDelete);
         model.updateFilteredJobList(Model.PREDICATE_SHOW_ALL_JOBS);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(jobToDeleteInterview)),
                 false, false, jobIndex);
@@ -100,8 +101,8 @@ public class InterviewDeleteCommand extends InterviewCommand {
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("Job index", jobIndex)
-                .add("Interview index", interviewIndex)
+                .add("jobIndex", jobIndex)
+                .add("interviewIndex", interviewIndex)
                 .toString();
     }
 

--- a/src/main/java/seedu/application/model/Model.java
+++ b/src/main/java/seedu/application/model/Model.java
@@ -7,6 +7,7 @@ import javafx.collections.ObservableList;
 import seedu.application.commons.core.GuiSettings;
 import seedu.application.model.job.FieldComparator;
 import seedu.application.model.job.Job;
+import seedu.application.model.job.interview.Interview;
 
 /**
  * The API of the Model component.
@@ -67,6 +68,12 @@ public interface Model {
      * The job must exist in the application book.
      */
     void deleteJob(Job target);
+
+    /**
+     * Deletes the given interview.
+     * The interview must exist in the application book.
+     */
+    void deleteInterview(Job job, Interview interview);
 
     /**
      * Adds the given job.

--- a/src/main/java/seedu/application/model/ModelManager.java
+++ b/src/main/java/seedu/application/model/ModelManager.java
@@ -13,6 +13,7 @@ import seedu.application.commons.core.LogsCenter;
 import seedu.application.commons.util.CollectionUtil;
 import seedu.application.model.job.FieldComparator;
 import seedu.application.model.job.Job;
+import seedu.application.model.job.interview.Interview;
 
 /**
  * Represents the in-memory model of the application book data.
@@ -97,6 +98,11 @@ public class ModelManager implements Model {
     @Override
     public void deleteJob(Job target) {
         applicationBook.removeJob(target);
+    }
+
+    @Override
+    public void deleteInterview(Job job, Interview interview) {
+        job.deleteInterview(interview);
     }
 
     @Override

--- a/src/main/java/seedu/application/model/job/Job.java
+++ b/src/main/java/seedu/application/model/job/Job.java
@@ -121,8 +121,8 @@ public class Job {
      * Deletes an interview in the list of interviews for a job.
      * The interview must exist for the job.
      */
-    public void deleteInterview(Index index) {
-        interviews.remove(index.getZeroBased());
+    public void deleteInterview(Interview interview) {
+        interviews.remove(interview);
     }
 
     /**

--- a/src/test/java/seedu/application/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/application/logic/commands/AddCommandTest.java
@@ -22,6 +22,7 @@ import seedu.application.model.ReadOnlyApplicationBook;
 import seedu.application.model.ReadOnlyUserPrefs;
 import seedu.application.model.job.FieldComparator;
 import seedu.application.model.job.Job;
+import seedu.application.model.job.interview.Interview;
 import seedu.application.testutil.JobBuilder;
 
 public class AddCommandTest {
@@ -76,7 +77,7 @@ public class AddCommandTest {
         assertNotEquals(addChefCommand, addCleanerCommand);
 
         // null -> returns false
-        assertNotEquals(null, addCleanerCommand);
+        assertNotEquals(addCleanerCommand, null);
     }
 
     @Test
@@ -142,6 +143,10 @@ public class AddCommandTest {
 
         @Override
         public void deleteJob(Job target) {
+            throw new AssertionError("This method should not be called.");
+        }
+        @Override
+        public void deleteInterview(Job job, Interview interview) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/application/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/application/logic/commands/DeleteCommandTest.java
@@ -6,8 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.application.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.application.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.application.logic.commands.CommandTestUtil.showJobAtIndex;
-import static seedu.application.testutil.TypicalIndexes.INDEX_FIRST_JOB;
-import static seedu.application.testutil.TypicalIndexes.INDEX_SECOND_JOB;
+import static seedu.application.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.application.testutil.TypicalIndexes.INDEX_SECOND;
 import static seedu.application.testutil.TypicalJobs.getTypicalApplicationBook;
 
 import org.junit.jupiter.api.Test;
@@ -29,8 +29,8 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
-        Job jobToDelete = model.getFilteredJobList().get(INDEX_FIRST_JOB.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_JOB);
+        Job jobToDelete = model.getFilteredJobList().get(INDEX_FIRST.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_JOB_SUCCESS,
                 Messages.format(jobToDelete));
@@ -51,10 +51,10 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_validIndexFilteredList_success() {
-        showJobAtIndex(model, INDEX_FIRST_JOB);
+        showJobAtIndex(model, INDEX_FIRST);
 
-        Job jobToDelete = model.getFilteredJobList().get(INDEX_FIRST_JOB.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_JOB);
+        Job jobToDelete = model.getFilteredJobList().get(INDEX_FIRST.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_JOB_SUCCESS,
                 Messages.format(jobToDelete));
@@ -68,9 +68,9 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_invalidIndexFilteredList_throwsCommandException() {
-        showJobAtIndex(model, INDEX_FIRST_JOB);
+        showJobAtIndex(model, INDEX_FIRST);
 
-        Index outOfBoundIndex = INDEX_SECOND_JOB;
+        Index outOfBoundIndex = INDEX_SECOND;
         // ensures that outOfBoundIndex is still in bounds of application book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getApplicationBook().getJobList().size());
 
@@ -81,14 +81,14 @@ public class DeleteCommandTest {
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_JOB);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_JOB);
+        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST);
+        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND);
 
         // same object -> returns true
         assertEquals(deleteFirstCommand, deleteFirstCommand);
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_JOB);
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST);
         assertEquals(deleteFirstCommand, deleteFirstCommandCopy);
 
         // different types -> returns false

--- a/src/test/java/seedu/application/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/application/logic/commands/EditCommandTest.java
@@ -11,8 +11,8 @@ import static seedu.application.logic.commands.CommandTestUtil.VALID_ROLE_CLEANE
 import static seedu.application.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.application.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.application.logic.commands.CommandTestUtil.showJobAtIndex;
-import static seedu.application.testutil.TypicalIndexes.INDEX_FIRST_JOB;
-import static seedu.application.testutil.TypicalIndexes.INDEX_SECOND_JOB;
+import static seedu.application.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.application.testutil.TypicalIndexes.INDEX_SECOND;
 import static seedu.application.testutil.TypicalJobs.getTypicalApplicationBook;
 
 import org.junit.jupiter.api.Test;
@@ -39,7 +39,7 @@ public class EditCommandTest {
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
         Job editedJob = new JobBuilder().build();
         EditJobDescriptor descriptor = new EditJobDescriptorBuilder(editedJob).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_JOB, descriptor);
+        EditCommand editCommand = new EditCommand(INDEX_FIRST, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_JOB_SUCCESS, Messages.format(editedJob));
 
@@ -91,8 +91,8 @@ public class EditCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_JOB, new EditJobDescriptor());
-        Job editedJob = model.getFilteredJobList().get(INDEX_FIRST_JOB.getZeroBased());
+        EditCommand editCommand = new EditCommand(INDEX_FIRST, new EditJobDescriptor());
+        Job editedJob = model.getFilteredJobList().get(INDEX_FIRST.getZeroBased());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_JOB_SUCCESS, Messages.format(editedJob));
 
@@ -103,11 +103,11 @@ public class EditCommandTest {
 
     @Test
     public void execute_filteredList_success() {
-        showJobAtIndex(model, INDEX_FIRST_JOB);
+        showJobAtIndex(model, INDEX_FIRST);
 
-        Job jobInFilteredList = model.getFilteredJobList().get(INDEX_FIRST_JOB.getZeroBased());
+        Job jobInFilteredList = model.getFilteredJobList().get(INDEX_FIRST.getZeroBased());
         Job editedJob = new JobBuilder(jobInFilteredList).withRole(VALID_ROLE_CLEANER).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_JOB,
+        EditCommand editCommand = new EditCommand(INDEX_FIRST,
             new EditJobDescriptorBuilder().withRole(VALID_ROLE_CLEANER).build());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_JOB_SUCCESS, Messages.format(editedJob));
@@ -120,20 +120,20 @@ public class EditCommandTest {
 
     @Test
     public void execute_duplicateJobUnfilteredList_failure() {
-        Job firstJob = model.getFilteredJobList().get(INDEX_FIRST_JOB.getZeroBased());
+        Job firstJob = model.getFilteredJobList().get(INDEX_FIRST.getZeroBased());
         EditJobDescriptor descriptor = new EditJobDescriptorBuilder(firstJob).build();
-        EditCommand editCommand = new EditCommand(INDEX_SECOND_JOB, descriptor);
+        EditCommand editCommand = new EditCommand(INDEX_SECOND, descriptor);
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_JOB);
     }
 
     @Test
     public void execute_duplicateJobFilteredList_failure() {
-        showJobAtIndex(model, INDEX_FIRST_JOB);
+        showJobAtIndex(model, INDEX_FIRST);
 
         // edit job in filtered list into a duplicate in application book
-        Job jobInList = model.getApplicationBook().getJobList().get(INDEX_SECOND_JOB.getZeroBased());
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_JOB,
+        Job jobInList = model.getApplicationBook().getJobList().get(INDEX_SECOND.getZeroBased());
+        EditCommand editCommand = new EditCommand(INDEX_FIRST,
             new EditJobDescriptorBuilder(jobInList).build());
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_JOB);
@@ -154,8 +154,8 @@ public class EditCommandTest {
      */
     @Test
     public void execute_invalidJobIndexFilteredList_failure() {
-        showJobAtIndex(model, INDEX_FIRST_JOB);
-        Index outOfBoundIndex = INDEX_SECOND_JOB;
+        showJobAtIndex(model, INDEX_FIRST);
+        Index outOfBoundIndex = INDEX_SECOND;
         // ensures that outOfBoundIndex is still in bounds of application book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getApplicationBook().getJobList().size());
 
@@ -167,11 +167,11 @@ public class EditCommandTest {
 
     @Test
     public void equals() {
-        final EditCommand standardCommand = new EditCommand(INDEX_FIRST_JOB, DESC_CHEF);
+        final EditCommand standardCommand = new EditCommand(INDEX_FIRST, DESC_CHEF);
 
         // same values -> returns true
         EditJobDescriptor copyDescriptor = new EditJobDescriptor(DESC_CHEF);
-        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_JOB, copyDescriptor);
+        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST, copyDescriptor);
         assertEquals(standardCommand, commandWithSameValues);
 
         // same object -> returns true
@@ -184,10 +184,10 @@ public class EditCommandTest {
         assertNotEquals(standardCommand, new ClearCommand());
 
         // different index -> returns false
-        assertNotEquals(standardCommand, new EditCommand(INDEX_SECOND_JOB, DESC_CHEF));
+        assertNotEquals(standardCommand, new EditCommand(INDEX_SECOND, DESC_CHEF));
 
         // different descriptor -> returns false
-        assertNotEquals(standardCommand, new EditCommand(INDEX_FIRST_JOB, DESC_CLEANER));
+        assertNotEquals(standardCommand, new EditCommand(INDEX_FIRST, DESC_CLEANER));
     }
 
     @Test

--- a/src/test/java/seedu/application/logic/commands/InterviewDeleteCommandTest.java
+++ b/src/test/java/seedu/application/logic/commands/InterviewDeleteCommandTest.java
@@ -1,0 +1,88 @@
+package seedu.application.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.application.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.application.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.application.testutil.TypicalIndexes.*;
+import static seedu.application.testutil.TypicalJobs.getTypicalApplicationBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.application.commons.core.index.Index;
+import seedu.application.logic.Messages;
+import seedu.application.model.Model;
+import seedu.application.model.ModelManager;
+import seedu.application.model.UserPrefs;
+import seedu.application.model.job.Job;
+
+class InterviewDeleteCommandTest {
+
+    private final Model model = new ModelManager(getTypicalApplicationBook(), new UserPrefs());
+    @Test
+    public void execute_validJobIndexWithValidInterviewIndex_success() {
+        ModelManager expectedModel = new ModelManager(model.getApplicationBook(), new UserPrefs());
+        Job jobToDeleteInterview = model.getFilteredJobList().get(INDEX_FIRST.getZeroBased());
+        String expectedMessage = String.format(InterviewDeleteCommand.MESSAGE_SUCCESS,
+                Messages.format(jobToDeleteInterview));
+
+        InterviewDeleteCommand interviewDeleteCommand = new InterviewDeleteCommand(INDEX_FIRST, INDEX_FIRST);
+
+        assertCommandSuccess(interviewDeleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validJobIndexWithInvalidInterviewIndex_throwsCommandException() {
+        Index jobIndex = Index.fromOneBased(model.getFilteredJobList().size());
+        Job jobToDeleteInterview = model.getFilteredJobList().get(jobIndex.getZeroBased());
+        Index outOfBoundsInterviewindex = Index.fromOneBased(jobToDeleteInterview.interviewLength() + 1);
+
+        InterviewDeleteCommand interviewDeleteCommand = new InterviewDeleteCommand(jobIndex, outOfBoundsInterviewindex);
+
+        assertCommandFailure(interviewDeleteCommand, model, Messages.MESSAGE_INVALID_INTERVIEW);
+    }
+
+    @Test
+    public void execute_invalidJobIndexWithValidInterviewIndex_throwsCommandException() {
+        Index outOfBoundsjobIndex = Index.fromOneBased(model.getFilteredJobList().size() + 1);
+        InterviewDeleteCommand interviewDeleteCommand = new InterviewDeleteCommand(outOfBoundsjobIndex, INDEX_FIRST);
+
+        assertCommandFailure(interviewDeleteCommand, model, Messages.MESSAGE_INVALID_JOB_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        InterviewDeleteCommand deleteInterviewFirstCommand = new InterviewDeleteCommand(INDEX_FIRST, INDEX_FIRST);
+        InterviewDeleteCommand deleteInterviewSecondCommand = new InterviewDeleteCommand(INDEX_SECOND, INDEX_FIRST);
+        InterviewDeleteCommand deleteInterviewThirdCommand = new InterviewDeleteCommand(INDEX_FIRST, INDEX_THIRD);
+
+        // same object -> returns true
+        assertEquals(deleteInterviewFirstCommand, deleteInterviewFirstCommand);
+
+        // same values -> returns true
+        InterviewDeleteCommand deleteFirstCommandCopy = new InterviewDeleteCommand(INDEX_FIRST, INDEX_FIRST);
+        assertEquals(deleteInterviewFirstCommand, deleteFirstCommandCopy);
+
+        // different types -> returns false
+        assertNotEquals(deleteInterviewFirstCommand, 5.0f);
+
+        // null -> returns false
+        assertNotEquals(deleteInterviewFirstCommand, null);
+
+        // different job index -> returns false
+        assertNotEquals(deleteInterviewFirstCommand, deleteInterviewSecondCommand);
+
+        // different interview index -> returns false
+        assertNotEquals(deleteInterviewFirstCommand, deleteInterviewThirdCommand);
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index jobIndex = Index.fromOneBased(1);
+        Index interviewIndex = Index.fromOneBased(1);
+        InterviewDeleteCommand interviewDeleteCommand = new InterviewDeleteCommand(jobIndex, interviewIndex);
+        String expected = InterviewDeleteCommand.class.getCanonicalName() + "{jobIndex=" + jobIndex + ", "
+                + "interviewIndex=" + interviewIndex + "}";
+        assertEquals(expected, interviewDeleteCommand.toString());
+    }
+}

--- a/src/test/java/seedu/application/logic/commands/InterviewDeleteCommandTest.java
+++ b/src/test/java/seedu/application/logic/commands/InterviewDeleteCommandTest.java
@@ -3,7 +3,6 @@ package seedu.application.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.application.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.application.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.application.testutil.TypicalIndexes.*;
 import static seedu.application.testutil.TypicalJobs.getTypicalApplicationBook;
 
@@ -19,18 +18,6 @@ import seedu.application.model.job.Job;
 class InterviewDeleteCommandTest {
 
     private final Model model = new ModelManager(getTypicalApplicationBook(), new UserPrefs());
-    @Test
-    public void execute_validJobIndexWithValidInterviewIndex_success() {
-        ModelManager expectedModel = new ModelManager(model.getApplicationBook(), new UserPrefs());
-        Job jobToDeleteInterview = model.getFilteredJobList().get(INDEX_FIRST.getZeroBased());
-        String expectedMessage = String.format(InterviewDeleteCommand.MESSAGE_SUCCESS,
-                Messages.format(jobToDeleteInterview));
-
-        InterviewDeleteCommand interviewDeleteCommand = new InterviewDeleteCommand(INDEX_FIRST, INDEX_FIRST);
-
-        assertCommandSuccess(interviewDeleteCommand, model, expectedMessage, expectedModel);
-    }
-
     @Test
     public void execute_validJobIndexWithInvalidInterviewIndex_throwsCommandException() {
         Index jobIndex = Index.fromOneBased(model.getFilteredJobList().size());

--- a/src/test/java/seedu/application/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/application/logic/commands/ListCommandTest.java
@@ -2,7 +2,7 @@ package seedu.application.logic.commands;
 
 import static seedu.application.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.application.logic.commands.CommandTestUtil.showJobAtIndex;
-import static seedu.application.testutil.TypicalIndexes.INDEX_FIRST_JOB;
+import static seedu.application.testutil.TypicalIndexes.INDEX_FIRST;
 import static seedu.application.testutil.TypicalJobs.getTypicalApplicationBook;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -34,7 +34,7 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
-        showJobAtIndex(model, INDEX_FIRST_JOB);
+        showJobAtIndex(model, INDEX_FIRST);
         String expectedMessage = String.format(ListCommand.MESSAGE_SUCCESS, 7);
         assertCommandSuccess(new ListCommand(), model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/application/logic/parser/ApplicationBookParserTest.java
+++ b/src/test/java/seedu/application/logic/parser/ApplicationBookParserTest.java
@@ -6,7 +6,7 @@ import static seedu.application.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.application.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.application.logic.parser.CliSyntax.*;
 import static seedu.application.testutil.Assert.assertThrows;
-import static seedu.application.testutil.TypicalIndexes.INDEX_FIRST_JOB;
+import static seedu.application.testutil.TypicalIndexes.INDEX_FIRST;
 
 import java.util.Arrays;
 import java.util.List;
@@ -45,8 +45,8 @@ public class ApplicationBookParserTest {
     @Test
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-            DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_JOB.getOneBased());
-        assertEquals(new DeleteCommand(INDEX_FIRST_JOB), command);
+            DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased());
+        assertEquals(new DeleteCommand(INDEX_FIRST), command);
     }
 
     @Test
@@ -54,8 +54,8 @@ public class ApplicationBookParserTest {
         Job job = new JobBuilder().build();
         EditJobDescriptor descriptor = new EditJobDescriptorBuilder(job).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-            + INDEX_FIRST_JOB.getOneBased() + " " + JobUtil.getEditJobDescriptorDetails(descriptor));
-        assertEquals(new EditCommand(INDEX_FIRST_JOB, descriptor), command);
+            + INDEX_FIRST.getOneBased() + " " + JobUtil.getEditJobDescriptorDetails(descriptor));
+        assertEquals(new EditCommand(INDEX_FIRST, descriptor), command);
     }
 
     @Test

--- a/src/test/java/seedu/application/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/application/logic/parser/DeleteCommandParserTest.java
@@ -3,7 +3,7 @@ package seedu.application.logic.parser;
 import static seedu.application.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.application.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.application.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.application.testutil.TypicalIndexes.INDEX_FIRST_JOB;
+import static seedu.application.testutil.TypicalIndexes.INDEX_FIRST;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +22,7 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_JOB));
+        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST));
     }
 
     @Test

--- a/src/test/java/seedu/application/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/application/logic/parser/EditCommandParserTest.java
@@ -12,9 +12,9 @@ import static seedu.application.logic.commands.CommandTestUtil.VALID_ROLE_CHEF;
 import static seedu.application.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static seedu.application.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.application.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.application.testutil.TypicalIndexes.INDEX_FIRST_JOB;
-import static seedu.application.testutil.TypicalIndexes.INDEX_SECOND_JOB;
-import static seedu.application.testutil.TypicalIndexes.INDEX_THIRD_JOB;
+import static seedu.application.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.application.testutil.TypicalIndexes.INDEX_SECOND;
+import static seedu.application.testutil.TypicalIndexes.INDEX_THIRD;
 
 import org.junit.jupiter.api.Test;
 
@@ -75,7 +75,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_allFieldsSpecified_success() {
-        Index targetIndex = INDEX_SECOND_JOB;
+        Index targetIndex = INDEX_SECOND;
         String userInput = targetIndex.getOneBased() + COMPANY_DESC_CLEANER + ROLE_DESC_CHEF;
 
         EditJobDescriptor descriptor = new EditJobDescriptorBuilder().withRole(VALID_ROLE_CHEF)
@@ -88,7 +88,7 @@ public class EditCommandParserTest {
     // To be implemented once more fields are added
     @Test
     public void parse_someFieldsSpecified_success() {
-        Index targetIndex = INDEX_FIRST_JOB;
+        Index targetIndex = INDEX_FIRST;
         String userInput = targetIndex.getOneBased() + COMPANY_DESC_CLEANER + ROLE_DESC_CHEF;
 
         EditJobDescriptor descriptor = new EditJobDescriptorBuilder().withCompany(VALID_COMPANY_CLEANER)
@@ -101,7 +101,7 @@ public class EditCommandParserTest {
     @Test
     public void parse_oneFieldSpecified_success() {
         // role
-        Index targetIndex = INDEX_THIRD_JOB;
+        Index targetIndex = INDEX_THIRD;
         String userInput = targetIndex.getOneBased() + ROLE_DESC_CHEF;
         EditJobDescriptor descriptor = new EditJobDescriptorBuilder().withRole(VALID_ROLE_CHEF).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
@@ -121,7 +121,7 @@ public class EditCommandParserTest {
         // AddCommandParserTest#parse_repeatedNonTagValue_failure()
 
         // valid followed by invalid
-        Index targetIndex = INDEX_THIRD_JOB;
+        Index targetIndex = INDEX_THIRD;
         String userInput = targetIndex.getOneBased() + INVALID_COMPANY_DESC + COMPANY_DESC_CLEANER;
 
         assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_COMPANY));

--- a/src/test/java/seedu/application/logic/parser/InterviewDeleteCommandParserTest.java
+++ b/src/test/java/seedu/application/logic/parser/InterviewDeleteCommandParserTest.java
@@ -1,0 +1,39 @@
+package seedu.application.logic.parser;
+
+import static seedu.application.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.application.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.application.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.application.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.application.testutil.TypicalIndexes.INDEX_THIRD;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.application.logic.commands.InterviewDeleteCommand;
+
+class InterviewDeleteCommandParserTest {
+
+    private InterviewDeleteCommandParser parser = new InterviewDeleteCommandParser();
+    @Test
+    void parse_validArgs_returnsInterviewDeleteCommand() {
+        assertParseSuccess(parser, "1 from/3", new InterviewDeleteCommand(INDEX_THIRD, INDEX_FIRST));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        //no indexes indicated
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, InterviewDeleteCommand.MESSAGE_USAGE));
+        //only job index indicated
+        assertParseFailure(parser, "2",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, InterviewDeleteCommand.MESSAGE_USAGE));
+        //no job index indicated
+        assertParseFailure(parser, "from/1",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, InterviewDeleteCommand.MESSAGE_USAGE));
+        //prefix not indicated
+        assertParseFailure(parser, "1 4",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, InterviewDeleteCommand.MESSAGE_USAGE));
+        //no interview index indicated
+        assertParseFailure(parser, "1 from/",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, InterviewDeleteCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/application/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/application/logic/parser/ParserUtilTest.java
@@ -3,7 +3,7 @@ package seedu.application.logic.parser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.application.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.application.testutil.Assert.assertThrows;
-import static seedu.application.testutil.TypicalIndexes.INDEX_FIRST_JOB;
+import static seedu.application.testutil.TypicalIndexes.INDEX_FIRST;
 
 import org.junit.jupiter.api.Test;
 
@@ -39,10 +39,10 @@ public class ParserUtilTest {
     @Test
     public void parseIndex_validInput_success() throws Exception {
         // No whitespaces
-        assertEquals(INDEX_FIRST_JOB, ParserUtil.parseIndex("1"));
+        assertEquals(INDEX_FIRST, ParserUtil.parseIndex("1"));
 
         // Leading and trailing whitespaces
-        assertEquals(INDEX_FIRST_JOB, ParserUtil.parseIndex("  1  "));
+        assertEquals(INDEX_FIRST, ParserUtil.parseIndex("  1  "));
     }
 
     @Test

--- a/src/test/java/seedu/application/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/application/testutil/TypicalIndexes.java
@@ -6,7 +6,7 @@ import seedu.application.commons.core.index.Index;
  * A utility class containing a list of {@code Index} objects to be used in tests.
  */
 public class TypicalIndexes {
-    public static final Index INDEX_FIRST_JOB = Index.fromOneBased(1);
-    public static final Index INDEX_SECOND_JOB = Index.fromOneBased(2);
-    public static final Index INDEX_THIRD_JOB = Index.fromOneBased(3);
+    public static final Index INDEX_FIRST = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND = Index.fromOneBased(2);
+    public static final Index INDEX_THIRD = Index.fromOneBased(3);
 }


### PR DESCRIPTION
1. Added test cases for InterviewDeleteCommand Class.
2. Added test cases for InterviewDeleteCommandParser Class.
3. Changed the logic to let ModelManager handle the deletion of interview instead of Job.
4. Changed the naming of indexes from FIRST_INDEX_JOB to FIRST_INDEX as some of the indexes are also used in the interview tests.