### PR TITLE
Update Deadline parser to accept and convert unformatted deadline

### DIFF
--- a/src/main/java/seedu/application/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/application/logic/parser/ParserUtil.java
@@ -76,10 +76,27 @@ public class ParserUtil {
     public static Deadline parseDeadline(String deadline) throws ParseException {
         requireNonNull(deadline);
         String trimmedDeadline = deadline.trim();
-        if (!Deadline.isValidDeadline(trimmedDeadline)) {
-            throw new ParseException(Deadline.MESSAGE_CONSTRAINTS);
+        String formattedDeadline = formatDeadline(trimmedDeadline);
+        if (!Deadline.isValidDeadline(formattedDeadline)) {
+            throw new ParseException(Deadline.MESSAGE_CONSTRAINTS + formattedDeadline);
         }
-        return new Deadline(trimmedDeadline);
+        return new Deadline(formattedDeadline);
+    }
+
+    /**
+     * Format the input format of {@code Deadline} field to match the default LocalDateTime format.
+     *
+     * @param deadline String deadline to be formatted.
+     * @return The formatted deadline in String.
+     */
+    private static String formatDeadline(String deadline) {
+        String[] stringSplit = deadline.split(" ");
+        if (stringSplit.length >= 3) {
+            String month = stringSplit[0];
+            month = month.substring(0, 1).toUpperCase() + month.substring(1).toLowerCase();
+            stringSplit[0] = month;
+        }
+        return String.join(" ", stringSplit);
     }
 
     /**

--- a/src/main/java/seedu/application/model/job/Deadline.java
+++ b/src/main/java/seedu/application/model/job/Deadline.java
@@ -50,9 +50,7 @@ public class Deadline {
         }
         try {
             LocalDateTime dateTime = LocalDateTime.parse(test, DATE_TIME_FORMATTER);
-            LocalDateTime current = LocalDateTime.now();
-            return dateTime.format(DATE_TIME_FORMATTER).equals(test)
-                && dateTime.isAfter(current);
+            return dateTime.format(DATE_TIME_FORMATTER).equals(test);
         } catch (Exception e) {
             return false;
         }

--- a/src/test/java/seedu/application/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/application/logic/parser/ParserUtilTest.java
@@ -38,8 +38,8 @@ public class ParserUtilTest {
 
     @Test
     public void parseIndex_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX,
-            () -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, () -> ParserUtil.parseIndex(
+            Long.toString(Integer.MAX_VALUE + 1)));
     }
 
     @Test

--- a/src/test/java/seedu/application/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/application/logic/parser/ParserUtilTest.java
@@ -8,7 +8,12 @@ import static seedu.application.testutil.TypicalIndexes.INDEX_FIRST;
 import org.junit.jupiter.api.Test;
 
 import seedu.application.logic.parser.exceptions.ParseException;
-import seedu.application.model.job.*;
+import seedu.application.model.job.Company;
+import seedu.application.model.job.Deadline;
+import seedu.application.model.job.Industry;
+import seedu.application.model.job.JobType;
+import seedu.application.model.job.Role;
+import seedu.application.model.job.Status;
 
 public class ParserUtilTest {
     private static final String INVALID_ROLE = "Softw@re Engineer";
@@ -20,6 +25,7 @@ public class ParserUtilTest {
     private static final String VALID_ROLE = "Software Engineer";
     private static final String VALID_COMPANY = "Google";
     private static final String VALID_DEADLINE = "Dec 31 2030 1200";
+    private static final String VALID_DEADLINE_UNFORMATTED = "dEc 31 2030 1200";
     private static final String VALID_STATUS = "Pending";
     private static final String VALID_JOBTYPE = "INTERNSHIP";
     private static final String VALID_INDUSTRY = "Finance";
@@ -33,7 +39,7 @@ public class ParserUtilTest {
     @Test
     public void parseIndex_outOfRangeInput_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
-            -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
+                                                                      -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
     }
 
     @Test
@@ -102,6 +108,12 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseDeadline_validUnformattedValue_returnsFormattedDeadline() throws Exception {
+        Deadline expectedDeadline = new Deadline(VALID_DEADLINE);
+        assertEquals(expectedDeadline, ParserUtil.parseDeadline(VALID_DEADLINE_UNFORMATTED));
+    }
+
+    @Test
     public void parseDeadline_validValueWithoutWhitespace_returnsDeadline() throws Exception {
         Deadline expectedDeadline = new Deadline(VALID_DEADLINE);
         assertEquals(expectedDeadline, ParserUtil.parseDeadline(VALID_DEADLINE));
@@ -113,6 +125,7 @@ public class ParserUtilTest {
         Deadline expectedDeadline = new Deadline(VALID_DEADLINE);
         assertEquals(expectedDeadline, ParserUtil.parseDeadline(deadlineWithWhitespace));
     }
+
     @Test
     public void parseStatus_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> ParserUtil.parseStatus((String) null));

--- a/src/test/java/seedu/application/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/application/logic/parser/ParserUtilTest.java
@@ -38,8 +38,8 @@ public class ParserUtilTest {
 
     @Test
     public void parseIndex_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
-                                                                      -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX,
+            () -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
     }
 
     @Test


### PR DESCRIPTION
- Deadline class now formats unformatted deadline string before parsing it as dateTime for new Deadline class
- Accepts case-sensitive month for DateTime format eg. Dec DEC dec dEc
- Removes condition for the deadline to be after current time

Closes 
- #137 
- #142
- #146 
- #149 
